### PR TITLE
Stop testing PhantomJS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,29 +8,14 @@ jobs:
       # care of installing a recent firefox and geckodriver (see below).
       - image: circleci/clojure:lein-2.9.3-browsers
 
-    environment:
-      # PhantomJS requires  an OpenSSL config even if it's an empty one,
-      # else it'll complain about "libssl_conf.so: cannot open shared object file"
-      # which seems to be a recent bug.
-      OPENSSL_CONF: /opt/openssl.cnf
-
     steps:
       - checkout
-      - run:
-          name: Install phantomjs
-          command: |
-            PHANTOMJS_VERSION=phantomjs-2.1.1-linux-x86_64 && \
-            wget --quiet --content-disposition https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOMJS_VERSION.tar.bz2 && \
-            sudo tar xf $PHANTOMJS_VERSION.tar.bz2 -C /usr/local && \
-            sudo ln -s /usr/local/$PHANTOMJS_VERSION/bin/phantomjs /usr/local/bin/phantomjs && \
-            rm  $PHANTOMJS_VERSION.tar.bz2
       - run:
           name: Environment information
           command: |
             firefox --version
             google-chrome --version
             chromedriver --version
-            phantomjs --version
 
       # We want to share the results of "lein deps" between runs.
       # We assume that the maven cache can change only if "project.clj"
@@ -60,13 +45,3 @@ jobs:
 
       - store_test_results:
           path: target/test2junit
-
-
-# TODO
-#
-# * Emit test results in XUNIT format so that CircleCI can provide useful
-#   statistics, see
-#   https://circleci.com/docs/2.0/configuration-reference/#store_test_results
-#
-# * (optimization) parallelize the test jobs with CircleCI `workflows`
-#

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,7 @@
 == Unreleased
 
 * https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows
+* https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS
 * Docs
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 * Internal quality

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,6 @@ RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/en
     && chmod +x /tmp/entrypoint \
     && mv /tmp/entrypoint /entrypoint.sh
 
-ENV ETAOIN_TEST_DRIVERS="[:firefox :chrome :phantom]"
+ENV ETAOIN_TEST_DRIVERS="[:firefox :chrome]"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Since `0.4.0`, Etaoin can play script files created in the interactive
 
 ## Capabilities
 
-- Currently supports Chrome, Firefox, Phantom.js and Safari (partially).
+- Currently supports Chrome, Firefox, and Safari (partially).
 - May either connect to a remote driver or run it on your local machine.
 - Run your unit tests directly from Emacs pressing `C-t t` as usual.
 - Can imitate human-like behaviour (delays, typos, etc).
@@ -189,7 +189,7 @@ Install specific drivers you need:
   - `brew install geckodriver` for Mac users
   - or download it from the official [Mozilla site][url-geckodriver-dl].
 
-- Phantom.js browser:
+- Phantom.js browser (obsolete, no longer tested):
 
   - `brew install phantomjs` For Mac users
   - or download it from the [official site][url-phantom-dl].

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -14,7 +14,7 @@
   https://github.com/mozilla/geckodriver
   https://github.com/mozilla/webdriver-rust/
 
-  Phantom.js (Ghostdriver)
+  Phantom.js (Ghostdriver) - obsolete and no longer tested
   https://github.com/detro/ghostdriver/blob/
   "
   (:require [etaoin.proc   :as proc]
@@ -1906,7 +1906,7 @@
   - JS console logs have `:console-api` for `:source` field.
   - Entries about errors will have SEVERE level.
 
-  * PhantomJS:
+  * PhantomJS (obsolete and no longer tested):
   - Return all recorded logs since the last URL change.
   - Does not clear recorded logs on subsequent invocations.
   - JS console logs have nil for `:source` field.

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -25,13 +25,13 @@
 
 (defn get-drivers-from-prop []
   (case (first (str/split (System/getProperty "os.name") #"\s+"))
-    "Linux"   [:firefox :chrome :phantom]
-    "Mac"     [:chrome :edge :firefox :phantom :safari]
-    "Windows" [:firefox :chrome :edge :phantom]
+    "Linux"   [:firefox :chrome]
+    "Mac"     [:chrome :edge :firefox :safari]
+    "Windows" [:firefox :chrome :edge]
     nil))
 
 (defn get-default-drivers []
-  [:firefox :chrome :phantom :safari])
+  [:firefox :chrome :safari])
 
 (def default-opts
   {:chrome  {:args ["--no-sandbox"]}


### PR DESCRIPTION
Existing code that supports PhantomJS remains, but we are no longer
launching tests for the, presumably obsolete, PhantomJS.

Closes #388