### PR TITLE
Report browser name (ex. firefox) when ide test fails

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,8 @@
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 ** https://github.com/clj-commons/etaoin/issues/396[#396]: Move from Markdown to AsciiDoc
 * Internal quality
-**  https://github.com/clj-commons/etaoin/issues/382[#382]: Fix process fork testing on Windows
+** https://github.com/clj-commons/etaoin/issues/382[#382]: Fix process fork testing on Windows
+** https://github.com/clj-commons/etaoin/issues/391[#391]: Identify browser name on failed ide tests
 
 == v0.4.6
 

--- a/test/etaoin/ide_test.clj
+++ b/test/etaoin/ide_test.clj
@@ -17,7 +17,8 @@
         (binding [*driver*         driver
                   *base-url*       base-url
                   *test-file-path* test-file-path]
-          (f))))))
+          (testing (name type)
+            (f)))))))
 
 (use-fixtures
   :each


### PR DESCRIPTION
Use existing technique found in api test.

Closes #391