### PR TITLE
Body now sent only for webdriver HTTP POST request

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 * https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows
 * https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS
 * https://github.com/clj-commons/etaoin/issues/384[#384]: Look for safaridriver on PATH by default
+* https://github.com/clj-commons/etaoin/issues/402[#402]: Only send body for webdriver POST requests to appease safaridriver
 * Docs
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 ** https://github.com/clj-commons/etaoin/issues/396[#396]: Move from Markdown to AsciiDoc

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -122,22 +122,21 @@
                     :method :get
                     :path   [:status]})))
 
-;; TODO safari: "Request body does not contain required parameter 'capabilities'."
 (defn create-session
   "Initiates a new session for a driver. Opens a browser window as a
   side-effect. All the further requests are made within specific
   session. Some drivers may work with only one active session. Returns
   a long string identifier."
   [driver & [capabilities]]
-  (let [data   (if (= (dispatch-driver driver) :safari) ;; tmp
-                 {:capabilities (or capabilities {})}
+  (let [data   (if (= (dispatch-driver driver) :safari)
+                 {:capabilities (or capabilities {})} ;; required for safari even if empty
                  {:desiredCapabilities (or capabilities {})})
         result (execute {:driver driver
                          :method :post
                          :path   [:session]
                          :data   data})]
     (or (:sessionId result)               ;; default
-        (:sessionId (:value result)))))   ;; firefox
+        (:sessionId (:value result)))))   ;; firefox, safari
 
 (defn delete-session
   "Deletes a session. Closes a browser window."

--- a/src/etaoin/client.clj
+++ b/src/etaoin/client.clj
@@ -29,7 +29,6 @@
    :content-type   :json
    :socket-timeout (* 1000 timeout)
    :conn-timeout   (* 1000 timeout)
-   :form-params    {}
    :debug          false})
 
 ;;
@@ -73,11 +72,12 @@
    method path-args payload]
   (let [path   (get-url-path path-args)
         url    (format "http://%s:%s/%s" host port path)
-        params (merge default-api-params
-                      {:url              url
-                       :method           method
-                       :form-params      (-> payload (or {}))
-                       :throw-exceptions false})
+        params (cond-> (merge
+                         default-api-params
+                         {:url              url
+                          :method           method
+                          :throw-exceptions false})
+                 (= :post method) (assoc :form-params (-> payload (or {}))))
 
         _ (log/debugf "%s %s:%s %6s %s %s"
                       (name driver-type)


### PR DESCRIPTION
Other webdriver implementations don't seem to care, but safaridriver
returns a 400 error when, for example, DELETE requests include a body.

Closes #402