### PR TITLE
Fix api select fn for safaridriver

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,10 +2,11 @@
 
 == Unreleased
 
-* https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows
-* https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS
-* https://github.com/clj-commons/etaoin/issues/384[#384]: Look for safaridriver on PATH by default
-* https://github.com/clj-commons/etaoin/issues/402[#402]: Only send body for webdriver POST requests to appease safaridriver
+* https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows, Apple no longer releases Safari for Windows
+* https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS, development has long ago stopped for PhantomJS
+* https://github.com/clj-commons/etaoin/issues/384[#384]: Look for `safaridriver` on PATH by default
+* https://github.com/clj-commons/etaoin/issues/402[#402]: Only send body for webdriver `POST` requests to appease `safaridriver`
+* https://github.com/clj-commons/etaoin/issues/403[#403]: The `select` fn now clicks on the `select` element before clicking the `option` element to appease `safaridriver`
 * Docs
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 ** https://github.com/clj-commons/etaoin/issues/396[#396]: Move from Markdown to AsciiDoc

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2783,18 +2783,21 @@
                     :arg     q-text}))))
 
 (defn select
-  "Select element in select-box by visible text on click.
+  "Select option in select-box by visible text on click.
+  The select element is clicked, then the option.
 
   Arguments:
 
   - `driver`: a driver instance,
 
-  - `q`: a query term, see `query` function for more info,
+  - `q`: a query term to find the select box, see [[query]],
 
   - `text`: a string, text in the option you want to select"
   [driver q text]
-  (let [el (query driver q {:tag :option :fn/has-text text})]
-    (click-el driver el)))
+  (let [select-el (query driver q)]
+    (click-el driver select-el)
+    (let [option-el (query driver q {:tag :option :fn/has-text text})]
+      (click-el driver option-el))))
 
 (defn clear-el
   "Clears an element by its identifier."


### PR DESCRIPTION
Webdriver implementations seem to handle a click directly on the option
element without first click on the select element.

Except for `safaridriver`. It needs us to click on the select element
before clicking on the option element.

This seems like a reasonable general flow, so did not special case for
`safaridriver`.

Closes #403