### PR TITLE
No longer testing multi key modifiers in send keys

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@
 * Internal quality
 ** https://github.com/clj-commons/etaoin/issues/382[#382]: Fix process fork testing on Windows
 ** https://github.com/clj-commons/etaoin/issues/391[#391]: Identify browser name on failed ide tests
+** https://github.com/clj-commons/etaoin/issues/387[#387]: No longer testing multiple key modifiers for a single webdriver send keys request
 
 == v0.4.6
 

--- a/resources/ide/test.side
+++ b/resources/ide/test.side
@@ -362,14 +362,14 @@
       "command": "sendKeys",
       "target": "id=simple-input",
       "targets": [],
-      "value": "${KEY_SHIFT}log${KEY_SHIFT}in"
+      "value": "log${KEY_SHIFT}in"
     }, {
       "id": "f3703b21-e986-4906-b938-c512add7659e",
       "comment": "",
       "command": "assertValue",
       "target": "id=simple-input",
       "targets": [],
-      "value": "LOGin"
+      "value": "logIN"
     }, {
       "id": "7923564d-6910-48d1-b03b-8b704750ab82",
       "comment": "",


### PR DESCRIPTION
After I noticed firefox was failing to handle state changes for multiple
key modifiers (e.g. shift key) in our ide tests, I did a little digging
and decided that might be actully adhering to the w3c webdriver spec
(see #387 for details).

Closes #387