### PR TITLE
Rename `etaoin.keys/num-.` to `etaoin.keys/num-dot`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,8 +1,20 @@
 = Changelog
 
-A release with an intentional breaking changes is marked with [breaking]
+A release with an intentional breaking changes is marked with:
 
-== Unreleased
+* [breaking] you probably need to change your code
+* [minor breaking] you likely don't need to change your code
+
+== Unreleased [minor breaking]
+
+Minor Breaking Changes
+
+* https://github.com/clj-commons/etaoin/issues/412[#412]: Rename `etaoin.keys/num-.` to `etaoin.keys/num-dot` +
+The symbol `num-.` is technically an invalid Clojure symbol and can confuse tooling. +
+A grep.app for `num-.` found Etaoin itself as the only user of this var.
+If your code uses `etaoin.keys/num-.`, you'll need to rename it to `etaoin.keys/num-dot`.
+
+Other Changes
 
 * https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows, Apple no longer releases Safari for Windows
 * https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS, development has long ago stopped for PhantomJS

--- a/src/etaoin/ide/api.clj
+++ b/src/etaoin/ide/api.clj
@@ -43,7 +43,7 @@
    "COMMAND"      k/command
    "CONTROL"      k/control-left
    "CTRL"         k/control-left
-   "DECIMAL"      #_{:clj-kondo/ignore [:unresolved-var]} k/num-.
+   "DECIMAL"      k/num-dot
    "DELETE"       k/delete
    "DIVIDE"       k/num-slash
    "DOWN"         k/arrow-down
@@ -93,7 +93,7 @@
    "NUMPAD7"      k/num-7
    "NUMPAD8"      k/num-9
    "NUMPAD9"      k/num-9
-   "NUM_PERIOD"   #_{:clj-kondo/ignore [:unresolved-var]} k/num-.
+   "NUM_PERIOD"   k/num-dot
    "NUM_PLUS"     k/num-+
    "NUM_DIVISION" k/num-slash
    "NUM_MULTIPLY" k/num-*

--- a/src/etaoin/keys.clj
+++ b/src/etaoin/keys.clj
@@ -41,7 +41,7 @@
 (def num-+              \uE025)
 (def num-comma          \uE026)
 (def num--              \uE027)
-(def num-.              \uE028)
+(def num-dot            \uE028)
 (def num-slash          \uE029)
 (def f1                 \uE031)
 (def f2                 \uE032)


### PR DESCRIPTION
The symbol `num-.` is technically an invalid Clojure symbol and can
confuse tooling.

Minor breaking change, see changelog for impact.

Closes #412