### PR TITLE
Window size test now makes window smaller

### DIFF
--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -404,7 +404,7 @@
     (let [{:keys [width height]} (get-window-size *driver*)]
       (is (numeric? width))
       (is (numeric? height))
-      (set-window-size *driver* (+ width 10) (+ height 10))
+      (set-window-size *driver* (- width 10) (- height 10))
       (let [{width' :width height' :height} (get-window-size *driver*)]
         (is (not= width width'))
         (is (not= height height'))))))


### PR DESCRIPTION
The test was attempting to make the Window bigger, but for firefox on macOS on
GitHub Actions, this was failing. GitHub Actions macOS has a relatively
small screen size, and firefox won't resize larger if we are at the
limits.

I think we are still covering the spirit of the test if we resize
smaller instead of bigger.

Fixes #419