### PR TITLE
road to bb: remove dependency on apache commons.io

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,8 @@
 
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
 
-  :dependencies [[clj-http "3.10.1"]
+  :dependencies [[babashka/fs "0.1.6"]
+                 [clj-http "3.10.1"]
                  [cheshire "5.9.0"]
                  [org.clojure/tools.cli "1.0.194"]
                  [org.clojure/tools.logging "0.3.1"]

--- a/src/etaoin/util.clj
+++ b/src/etaoin/util.clj
@@ -1,8 +1,8 @@
 (ns etaoin.util
+  (:require [babashka.fs :as fs])
   (:import java.io.File
            java.nio.file.attribute.FileAttribute
-           java.nio.file.Files
-           org.apache.commons.io.FileUtils))
+           java.nio.file.Files))
 
 (defn map-or-nil?
   [x]
@@ -81,4 +81,4 @@
      (try
        ~@body
        (finally
-         (FileUtils/deleteDirectory (File. tmp#))))))
+         (fs/delete-tree tmp#)))))


### PR DESCRIPTION
Etaoin was using apache commons.io to delete a tempoarary dir.
This dependency was brought in implicitly by clj-http.

Replaced with babashka/fs delete-tree.

Out of scope: Using more babashka/fs than we need to. This libary
has some great abstractions that I expect will help with maintainability,
we'll get to this later.

Contributes to #380