### PR TITLE
road to bb: ImageIO no longer used in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,14 @@ jobs:
         key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
         restore-keys: cljdeps-
 
+    - name: "Install Missing Windows Bits"
+      if: ${{ matrix.os == 'windows' }}
+      run: |
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        choco install --no-progress --yes imagemagick
+        refreshenv
+        Write-Output "$env:PATH" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: "Setup Java"
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
We were using java's ImageIO to validate that we could successfully read
screenshot png images. There's nothing wrong with this, but babashka
does not currently include ImageIO support.

So I've switch to calling out to Image Magick to validate our screenshot
png are valid.

A minor developer setup burden for bb compatibility.

Contributes to #380