### PR TITLE
road to bb: more babashka fs usage

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -29,6 +29,7 @@
             [clojure.java.io           :as io]
             [clojure.string            :as str]
 
+            [babashka.fs :as fs]
             [cheshire.core       :refer [generate-stream]]
             [slingshot.slingshot :refer [try+ throw+]])
 
@@ -2825,7 +2826,7 @@
 
 (defmethod upload-file String
   [driver q path]
-  (upload-file driver q (io/file path)))
+  (upload-file driver q (fs/file path)))
 
 (defmethod upload-file java.io.File
   [driver q ^java.io.File file]
@@ -2995,7 +2996,6 @@
 
 ;; TODO add w3c screenshot
 (defmulti screenshot-element
-
   {:arglists '([driver q file])}
   dispatch-driver)
 
@@ -3021,7 +3021,7 @@
   (->> (.getTime (java.util.Date.))
        (format "-%d.png")
        (str (name driver-type))
-       (io/file dir)
+       (fs/file dir)
        str))
 
 (defmacro with-screenshots
@@ -3041,7 +3041,7 @@
 (defn join-path
   "Joins two and more path components into a single file path OS-wisely."
   [p1 p2 & more]
-  (.getPath ^java.io.File (apply io/file p1 p2 more)))
+  (.getPath ^java.io.File (apply fs/file p1 p2 more)))
 
 (defn format-date
   [date pattern]
@@ -3072,9 +3072,9 @@
         path-src (join-path dir-src file-src)
         path-log (join-path dir-log file-log)]
 
-    (clojure.java.io/make-parents path-img)
-    (clojure.java.io/make-parents path-src)
-    (clojure.java.io/make-parents path-log)
+    (io/make-parents path-img)
+    (io/make-parents path-src)
+    (io/make-parents path-log)
 
     (log/debugf "Writing screenshot: %s" path-img)
     (screenshot driver path-img)

--- a/src/etaoin/driver.clj
+++ b/src/etaoin/driver.clj
@@ -34,9 +34,9 @@
   https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/firefox/options.py
   "
   (:require [etaoin.util :refer [defmethods deep-merge]]
+            [babashka.fs :as fs]
             [clojure.string :as string]
-            [clojure.tools.logging :as log])
-  (:import (java.io File)))
+            [clojure.tools.logging :as log]))
 
 (defn dispatch-driver
   [driver & _]
@@ -157,12 +157,12 @@
   ;; Chrome adds the trailing `/Default` part to the profile path.
   ;; To prevent duplication, let's clear the given path manually.
   [driver ^String profile]
-  (let [profile       (File. profile)
-        ^File profile (if (= "Default" (.getName profile))
-                        (.getParent profile)
-                        profile)
-        user-data-dir (str (.getParent profile))
-        profile-dir   (str  (.getName profile))]
+  (let [profile       (fs/file profile)
+        profile (if (= "Default" (fs/file-name profile))
+                  (fs/parent profile)
+                  profile)
+        user-data-dir (str (fs/parent profile))
+        profile-dir   (str  (fs/file-name profile))]
     (set-options-args driver [(format "--user-data-dir=%s" user-data-dir)
                               (format "--profile-directory=%s" profile-dir)])))
 

--- a/src/etaoin/util.clj
+++ b/src/etaoin/util.clj
@@ -72,13 +72,3 @@
        ~@body
        (finally
          (.delete tmp#)))))
-
-(defmacro with-tmp-dir [prefix bind & body]
-  `(let [tmp#  (str (Files/createTempDirectory
-                      ~prefix
-                      (into-array FileAttribute [])))
-         ~bind tmp#]
-     (try
-       ~@body
-       (finally
-         (fs/delete-tree tmp#)))))

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -7,7 +7,7 @@
             [clojure.test :refer :all]
             [etaoin.api :refer :all]
             [etaoin.test-report :as test-report]
-            [etaoin.util :refer [with-tmp-dir with-tmp-file]]
+            [etaoin.util :refer [with-tmp-file]]
             [slingshot.slingshot :refer [try+]]))
 
 (defn numeric? [val]
@@ -588,12 +588,12 @@
     (is (valid-image? path))))
 
 (deftest test-with-screenshots
-  (with-tmp-dir "screenshots" dir
+  (fs/with-temp-dir [dir {:prefix "screenshots"}]
     (with-screenshots *driver* dir
       (fill *driver* :simple-input "1")
       (fill *driver* :simple-input "1")
       (fill *driver* :simple-input "1"))
-    (is (= 3 (count (.listFiles (io/file dir)))))))
+    (is (= 3 (count (fs/list-dir dir))))))
 
 (deftest test-screenshot-element
   (when (or (chrome? *driver*)
@@ -711,7 +711,7 @@
         (is false "should be caught")
         (catch Exception _e
           (is true "caught")
-          (let [files               (file-seq (io/file dir-tmp))
+          (let [files               (file-seq (fs/file dir-tmp))
                 expected-file-count (if (supports-logs? *driver*) 3 2)]
             (is (= (-> files rest count)
                    expected-file-count))))))))

--- a/test/etaoin/unit/unit_test.clj
+++ b/test/etaoin/unit/unit_test.clj
@@ -1,14 +1,12 @@
 (ns etaoin.unit.unit-test
-  (:require [clojure.spec.alpha :as s]
+  (:require [babashka.fs :as fs]
+            [clojure.spec.alpha :as s]
             [clojure.test :refer :all]
             [etaoin.api :refer :all]
             [etaoin.ide.flow :as ide]
             [etaoin.ide.spec :as spec]
-            [etaoin.util :refer [with-tmp-dir]]
             [etaoin.test-report]
-            etaoin.proc)
-  (:import java.io.File))
-
+            etaoin.proc))
 
 (deftest test-firefox-driver-args
   (with-redefs
@@ -37,8 +35,8 @@
                (:args driver)))))))
 
 (deftest test-chrome-profile
-  (with-tmp-dir "chrome-dir" chrome-dir
-    (let [profile-path (str (File. chrome-dir "chrome-profile"))]
+  (fs/with-temp-dir [chrome-dir {:prefix "chrome-dir"}]
+    (let [profile-path (str (fs/file chrome-dir "chrome-profile"))]
       (with-chrome {:profile profile-path :args ["--no-sandbox"]} driver
         (go driver "chrome://version")
         (is profile-path


### PR DESCRIPTION
Replaced direct JDK references with babashka fs abstractions.

Of note:
- turfed etaoin.util/with-tmp-dir and replaced its usages with babashka
fs equivalent (Files/createTempDirectory is unavailable in bb, I think).
We've decided that etaoin.util is not part of our public API #430, so not
worried about deleting this macro.
- some references to io/file replaced with fs/file for more flexible coercion.

Contributes to #380