### PR TITLE
Bump dependencies to current releases

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -60,6 +60,7 @@ This will allow for easier testing of unreleased versions of Etaoin via git deps
 It also unconvered that our minimum Clojure version was 1.10, instead of the advertised v1.9.
 Fixed.
 * https://github.com/clj-commons/etaoin/issues/444[#444]: Visibility checks fixed for firefox and chrome (thanks https://github.com/daveyarwood[@daveyarwood]!)
+* https://github.com/clj-commons/etaoin/issues/446[#446]: Bump Etaoin dependencies to current releases
 * Docs
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 ** https://github.com/clj-commons/etaoin/issues/426[#426]: Reorganize into separate guides

--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
-{:paths ["script"]
+{:min-bb-version "0.8.2"
+ :paths ["script"]
  :deps {doric/doric {:mvn/version "0.9.0"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         babashka/fs {:mvn/version "0.1.6"}
         clj-http/clj-http {:mvn/version "3.12.3"} ;; for jvm use
         org.clj-commons/clj-http-lite {:mvn/version "0.4.392"} ;; for babashka use
-        cheshire/cheshire {:mvn/version "5.10.2"}
+        cheshire/cheshire {:mvn/version "5.11.0"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.9.0"} ;; min clojure version
         babashka/fs {:mvn/version "0.1.6"}
-        clj-http/clj-http {:mvn/version "3.10.1"} ;; for jvm use
+        clj-http/clj-http {:mvn/version "3.12.3"} ;; for jvm use
         org.clj-commons/clj-http-lite {:mvn/version "0.4.392"} ;; for babashka use
-        cheshire/cheshire {:mvn/version "5.9.0"}
-        org.clojure/tools.cli {:mvn/version "1.0.194"}
-        org.clojure/tools.logging {:mvn/version "0.3.1"}}
+        cheshire/cheshire {:mvn/version "5.10.2"}
+        org.clojure/tools.cli {:mvn/version "1.0.206"}
+        org.clojure/tools.logging {:mvn/version "1.2.4"}}
  :aliases
  {:1.11 {:replace-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
   :debug {:extra-paths ["env/dev/resources"]}
@@ -18,7 +18,7 @@
   :script {:extra-paths ["script"]}
   ;; for babashka testing, needed for eatoin.ide
   :bb-spec {:extra-deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
-                                                  :sha "644a7fc216e43d5da87b07471b0f87d874107d1a"}}}
+                                                  :sha "8df0712896f596680da7a32ae44bb000b7e45e68"}}}
   ;; for babashka testing, allows us to use cognitect test-runner
   :bb-test {:extra-deps {org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
                                                       :git/sha "a13b037215e21a2e71aa34b27e1dd52c801a2a7b"}}}


### PR DESCRIPTION
Also: specify minimum babashka version.

Closes #446