### PR TITLE
User guide and usage related updates

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,8 +7,4 @@
  ;; finer grained error reporting
  {:macroexpand
   {etaoin.impl.util/defmethods etaoin.impl.util/defmethods
-   etaoin.impl.util/with-tmp-file etaoin.impl.util/with-tmp-file}}
-
- :linters
- ;; etaoin is dsl-ish and does make use of :refer :all, can decide if we like that at some later date
- {:refer-all {:level :off}}}
+   etaoin.impl.util/with-tmp-file etaoin.impl.util/with-tmp-file}}}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -65,8 +65,11 @@ Fixed.
 * Docs
 ** https://github.com/clj-commons/etaoin/issues/393[#393]: Add changelog
 ** https://github.com/clj-commons/etaoin/issues/426[#426]: Reorganize into separate guides
-** https://github.com/clj-commons/etaoin/commit/f3f0370fb76bc353c14293243410db1641f99c70[f3f0370]: A new troubleshooting tip (thanks https://github.com/jkrasnay[@jkrasnay]!)
 ** https://github.com/clj-commons/etaoin/issues/396[#396]: Move from Markdown to AsciiDoc
+** User guide
+*** Reviewed, re-organized, hopefully clarified some things
+*** Checking code blocks with https://github.com/lread/test-doc-blocks[test-doc-blocks]
+*** https://github.com/clj-commons/etaoin/commit/f3f0370fb76bc353c14293243410db1641f99c70[f3f0370]: A new troubleshooting tip (thanks https://github.com/jkrasnay[@jkrasnay]!)
 * Internal quality
 ** https://github.com/clj-commons/etaoin/issues/382[#382]: Fix process fork testing on Windows
 ** https://github.com/clj-commons/etaoin/issues/391[#391]: Identify browser name on failed ide tests

--- a/bb.edn
+++ b/bb.edn
@@ -27,6 +27,8 @@
                                          "--nrepl-server"))}
   test           {:doc "run all or a subset of tests, use --help for args"
                   :task test/-main}
+  test-doc       {:doc "test code blocks in user guide"
+                  :task test-doc/-main}
   drivers        {:doc "[list|kill] any running WebDrivers"
                   :task drivers/-main}
   lint           {:doc "[--rebuild] lint source code"

--- a/deps.edn
+++ b/deps.edn
@@ -22,8 +22,23 @@
   ;; for babashka testing, allows us to use cognitect test-runner
   :bb-test {:extra-deps {org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
                                                       :git/sha "a13b037215e21a2e71aa34b27e1dd52c801a2a7b"}}}
+
+  ;; test-doc-blocks - gen tests
+  :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.11.1"}
+                                   com.github.lread/test-doc-blocks  {:mvn/version "1.0.166-alpha"}}
+                    :replace-paths []
+                    :ns-default lread.test-doc-blocks
+                    :exec-args {:docs ["doc/01-user-guide.adoc"]}}
+
+  ;; test-doc-blocks - run tests
+  ;; usage: test:test-docs
+  :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+              :extra-paths ["target/test-doc-blocks/test"]
+              :main-opts ["-m" "cognitect.test-runner"
+                          "-d" "target/test-doc-blocks/test"]}
+
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.29"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.31"}}
               :main-opts ["-m" "clj-kondo.main"]}
 
   :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -212,11 +212,15 @@ See <<troubleshooting>> if you have problems - or reach out on link:{url-slack}[
 The great news is that you can automate your browser directly from your Babashka or Clojure REPL.
 Let's interact with Wikipedia:
 
-// A little invisible cheat for better test-doc-block reporting when running generated tests
+// A little invisible codeblock for some setup
 ifdef::env-test-doc-blocks[]
 [source,clojure]
 ----
+(require '[babashka.fs :as fs])
+;; for better test-doc-block reporting when running generated tests
 (require '[etaoin.test-report])
+;; for screenshots save dir (dir must currently exist)
+(fs/create-dirs "target/etaoin-play")
 ----
 endif::[]
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1,18 +1,26 @@
 // NOTE: release workflow automatically updates etaoin versions in this file
+// NOTE: many of the clojure code blocks in this file are tested via lread/test-doc-block
 = User Guide
 :toclevels: 5
 :toc:
 :lib-version: 0.4.6
+:project-src-coords: clj-commons/etaoin
+:project-mvn-coords: etaoin/etaoin
+:url-webdriver: https://www.w3.org/TR/webdriver/
+:url-sample-page: http://{project-src-coords}/doc/user-guide-sample.html
+:url-doc: https://cljdoc.org/d/{project-mvn-coords}
 :url-tests: https://github.com/{project-src-coords}/blob/master/test/etaoin/api_test.clj
+:url-slack: https://clojurians.slack.com/archives/C7KDM0EKW
 
 == Introduction
 
 Etaoin offers the Clojure community a simple way to script web browser interactions from Clojure and Babashka.
+It is a thin abstraction atop the link:{url-webdriver}[W3C WebDriver protocol] that also endeavors to resolve real-world nuances and implementation differences.
 
 === History
 
 Ivan Grishaev (https://github.com/igrishaev[@igrishaev]) created Etaoin and published its first release to Clojars in Feb of 2017.
-He and his band of faithful contributors grew Etaoin into a well respected goto library for browser automation.
+He and his band of faithful contributors grew Etaoin into a well respected goto-library for browser automation.
 
 In May of 2022, finding his time had gravitated more to back-end development, Ivan offered Etaoin for adoption to clj-commons where it is now currently under the loving care of https://github.com/lread[@lread] and https://github.com/borkdude[@borkdude].
 
@@ -25,7 +33,7 @@ If Etaoin is not your cup of tea, you might also consider:
 [[supported-os-browser]]
 === Supported OSes & Browsers
 
-Etaoin's test suite covers the following OSes and browsers run with both regular Clojure and Babashka:
+Etaoin's test suite covers the following OSes and browsers for both Clojure and Babashka:
 
 |===
 | OS | Chrome | Firefox | Safari | Edge
@@ -50,7 +58,7 @@ Etaoin's test suite covers the following OSes and browsers run with both regular
 
 |===
 
-NOTE: At one point we did also test against PhantomJS, but since work has long ago stopped for this project we have dropped testing.
+NOTE: At one point we did also test against PhantomJS, but since work has long ago stopped on this project we have dropped testing.
 
 == Installation
 
@@ -59,19 +67,20 @@ There are two steps to installation:
 . Add the `etaoin` library as a dependency to your project
 . Install the WebDriver for each web browser you'd like control with Etaoin
 
-=== Installing the etaoin library
+=== Installing the Etaoin Library
 
 ==== For Clojure Users
 
 Etaoin supports Clojure v1.9 and above.
 
-Add the following into `:dependencies` vector in your `project.clj` file:
+Add the following into the `:dependencies` vector in your `project.clj` file:
 
 [source,clojure,subs="attributes+"]
 ----
    [etaoin "{lib-version}"]
 ----
 
+//:test-doc-blocks/skip
 Or the following under `:deps` in your `deps.edn` file:
 [source,clojure,subs="attributes+"]
 ----
@@ -84,25 +93,28 @@ We recommend the current release of https://book.babashka.org/#_installation[bab
 
 Add the following under `:deps` to your `bb.edn` file:
 
+//:test-doc-blocks/skip
 [source,clojure,subs="attributes+"]
 ----
    etaoin/etaoin {:mvn/version "{lib-version}"}
 ----
 
-The Etaoin feature to <<selenium-ide, run Selenium IDE files>> employs clojure spec. If you are using this feature, you'll need to also enable clojure spec support in Babashka by adding `babashka/spec.alpha` to your `bb.edn` `:deps`:
+The Etaoin feature to <<selenium-ide, run Selenium IDE files>> employs clojure spec.
+If you are using this feature, you'll need to also enable clojure spec support in Babashka by adding `babashka/spec.alpha` to your `bb.edn` `:deps`:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
    org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
-                            :sha "644a7fc216e43d5da87b07471b0f87d874107d1a"}}}
+                            :sha "8df0712896f596680da7a32ae44bb000b7e45e68"}
 ----
 
 See https://github.com/babashka/spec.alpha[babashka/spec.alpha] for current docs.
 
 :url-webdriver: https://www.w3.org/TR/webdriver/
 :url-tests: https://github.com/{project-src-coords}/blob/master/test/etaoin/api_test.clj
-:url-chromedriver: https://sites.google.com/a/chromium.org/chromedriver/
-:url-chromedriver-dl: https://sites.google.com/a/chromium.org/chromedriver/downloads
+:url-chromedriver: https://sites.google.com/chromium.org/driver/
+:url-chromedriver-dl: https://sites.google.com/chromium.org/driver/downloads
 :url-geckodriver-dl: https://github.com/mozilla/geckodriver/releases
 :url-phantom-dl: http://phantomjs.org/download.html
 :url-webkit: https://webkit.org/blog/6900/webdriver-support-in-safari-10/
@@ -116,7 +128,7 @@ Each browser has its own WebDriver implementation which must be installed.
 
 [TIP]
 ====
-If it is not already installed, download the web browser you'd like to control (Chrome, Firefox, Edge) as per normal, which is usually by downloading it from its official site.
+If it is not already installed, download the web browser you'd like to control (Chrome, Firefox, Edge) as per normal - which is usually by downloading it from its official site.
 Safari comes bundled with macOS.
 ====
 
@@ -166,74 +178,93 @@ phantomjs --wd
 ----
 
 If you like, you can run Etaoin's test suite to verify your installation.
-From a clone of the https://github.com/clj-commons/etaoin[Etaoin GitHub repo]:
 
+TIP: Some Etaoin API tests rely on ImageMagick, install it prior to running test.
+
+From a clone of the https://github.com/clj-commons/etaoin[Etaoin GitHub repo]
+
+* To check tools of interest to Etaoin:
++
+[source,bash]
+----
+bb tools-versions
+----
+* Run all tests:
++
 [source,bash]
 ----
 bb test all
 ----
-
-For a smaller sanity test, you might want to run api tests against browsers you are particularly intested in. Example:
-
+* For a smaller sanity test, you might want to run api tests against browsers you are particularly intested in. Example:
++
 [source,bash]
 ----
 bb test api --browser chrome
 ----
 
-You'll see browser windows open and close in series.
+When tests are running, you'll see browser windows open and close in series.
 The tests use a local HTML file with a special layout to validate most interactions.
 
-See below for <<troubleshooting>> if you have problems
+See <<troubleshooting>> if you have problems - or reach out on link:{url-slack}[Clojurians Slack #etaoin] or https://github.com/clj-commons/etaoin/issues[GitHub issues].
 
-== Getting started
+== Getting Started
 
-The good news is that you can automate your browser directly from your Babashka or Clojure REPL:
+The great news is that you can automate your browser directly from your Babashka or Clojure REPL.
+Let's interact with Wikipedia:
+
+// A little invisible cheat for better test-doc-block reporting when running generated tests
+ifdef::env-test-doc-blocks[]
+[source,clojure]
+----
+(require '[etaoin.test-report])
+----
+endif::[]
 
 [source,clojure]
 ----
-(require '[etaoin.api :as api]
+(require '[etaoin.api :as e]
          '[etaoin.keys :as k])
 
 ;; Start WebDriver for Firefox
-(def driver (api/firefox)) ;; a Firefox window should appear
+(def driver (e/firefox)) ;; a Firefox window should appear
 
 ;; let's perform a quick Wiki session
 
 ;; navigate to wikipedia
-(api/go driver "https://en.wikipedia.org/")
+(e/go driver "https://en.wikipedia.org/")
 ;; wait for the search input to load
-(api/wait-visible driver [{:id :simpleSearch} {:tag :input :name :search}])
+(e/wait-visible driver [{:id :simpleSearch} {:tag :input :name :search}])
 
 ;; search for something interesting
-(api/fill driver {:tag :input :name :search} "Clojure programming language")
-(api/fill driver {:tag :input :name :search} k/enter)
-(api/wait-visible driver {:class :mw-search-results})
+(e/fill driver {:tag :input :name :search} "Clojure programming language")
+(e/fill driver {:tag :input :name :search} k/enter)
+(e/wait-visible driver {:class :mw-search-results})
 
 ;; click on first match
-(api/click driver [{:class :mw-search-results} {:class :mw-search-result-heading} {:tag :a}])
-(api/wait-visible driver {:id :firstHeading})
+(e/click driver [{:class :mw-search-results} {:class :mw-search-result-heading} {:tag :a}])
+(e/wait-visible driver {:id :firstHeading})
 
 ;; check our new url location
-(api/get-url driver)
+(e/get-url driver)
 ;; => "https://en.wikipedia.org/wiki/Clojure"
 
 ;; and our new title
-(api/get-title driver)
+(e/get-title driver)
 ;; => "Clojure - Wikipedia"
 
 ;; does page have Clojure in it?
-(api/has-text? driver "Clojure")
+(e/has-text? driver "Clojure")
 ;; => true
 
 ;; navigate through history
-(api/back driver)
-(api/forward driver)
-(api/refresh driver)
-(api/get-title driver)
+(e/back driver)
+(e/forward driver)
+(e/refresh driver)
+(e/get-title driver)
 ;; => "Clojure - Wikipedia"
 
 ;; stops Firefox WebDriver
-(api/quit driver) ;; the Firefox Window should close
+(e/quit driver) ;; the Firefox Window should close
 ----
 
 Most api functions require the driver as the first argument.
@@ -242,127 +273,251 @@ A portion of the above rewritten with `doto`:
 
 [source,clojure]
 ----
-(use '[etaoin.api :refer :all])
-(require '[etaoin.keys :as k])
+(require '[etaoin.api :as e]
+         '[etaoin.keys :as k])
 
-(def driver (firefox))
+(def driver (e/firefox))
 
 (doto driver
-  (go "https://en.wikipedia.org/")
-  (wait-visible [{:id :simpleSearch} {:tag :input :name :search}])
-  (fill {:tag :input :name :search} "Clojure programming language")
-  (fill {:tag :input :name :search} k/enter)
-  (wait-visible {:class :mw-search-results})
-  (click [{:class :mw-search-results} {:class :mw-search-result-heading} {:tag :a}])
-  (wait-visible {:id :firstHeading})
-  (quit))
+  (e/go "https://en.wikipedia.org/")
+  (e/wait-visible [{:id :simpleSearch} {:tag :input :name :search}])
+  (e/fill {:tag :input :name :search} "Clojure programming language")
+  (e/fill {:tag :input :name :search} k/enter)
+  (e/wait-visible {:class :mw-search-results})
+  (e/click [{:class :mw-search-results} {:class :mw-search-result-heading} {:tag :a}])
+  (e/wait-visible {:id :firstHeading})
+  (e/quit))
 ----
 
-You can use `fill-multi` to shorten the code like:
+== Playing Along in your REPL
+We encourage you to try the examples in from this user guide in your REPL.
 
-[source,clojure]
-----
-(fill driver :login "login")
-(fill driver :password "pass")
-(fill driver :textarea "some text")
-----
+The Interwebs is in constant change, so while using live sites is attractive, this code in this user guide has instead been tested to work against our link:{url-sample-page}[little sample page].
 
-into
+Until we figure out something more clever, it might be easiest to clone the etaoin GitHub repository and run a REPL from there.
+
+Unless otherwise directed, our examples throughout the rest of this guide will assume you've already done the equivalent of:
 
 [source,clojure]
 ----
-(fill-multi driver {:login "login"
-                    :password "pass"
-                    :textarea "some text"})
+(require '[etaoin.api :as e]
+         '[etaoin.api2 :as e2]
+         '[etaoin.keys :as k]
+         '[clojure.java.io :as io])
+
+(def sample-page (-> "doc/user-guide-sample.html" io/file .toURI str))
+
+(def driver (e/chrome)) ;; or replace chrome with your preference
+(e/go driver sample-page)
 ----
 
-If any exception occurs during a browser session, the WebDriver process might hang forever until you kill it manually.
-To prevent that, use `with-<browser>` macros as follows:
+== More Getting Started
+
+You can use `fill-multi` to shorten the code like so:
 
 [source,clojure]
 ----
-(with-firefox {} ff ;; additional options first, then bind name
-  (doto ff
-    (go "https://google.com")
-    ...))
+(e/fill driver :uname "username")
+(e/fill driver :pw "pass")
+(e/fill driver :text "some text")
+
+;; let's get what we just set:
+(mapv #(e/get-element-value driver %) [:uname :pw :text])
+;; => ["username" "pass" "some text"]
+----
+
+into:
+
+[source,clojure]]
+----
+;; issue a browser refresh
+(e/refresh driver)
+(e/fill-multi driver {:uname "username2"
+                      :pw "pass2"
+                      :text "some text2"})
+
+;; to get what we just set:
+(mapv #(e/get-element-value driver %) [:uname :pw :text])
+;; => ["username2" "pass2" "some text2"]
+----
+
+If any exception occurs during a browser session, the WebDriver process might hang until you kill it manually.
+To prevent that, we recommend the `with-<browser>` macros:
+
+[source,clojure]
+----
+(require '[etaoin.api2 :as e2])
+
+(e2/with-firefox [driver]
+  (doto driver
+    (e/go "https://google.com")
+    ;; ... your code here
+    ))
 ----
 
 This will ensure that the WebDriver process is closed regardless of what happens.
 
 == Unit Tests as Docs
 
-The sections that follow describe, how to use Etaoin.
+The sections that follow describe, how to use Etaoin in more depth.
 
-In addition to these docs the link:{url-tests}[Etaoin api tests] are also a good reference.
+In addition to these docs, the link:{url-tests}[Etaoin api tests] are also a good reference.
 
-== Querying elements
+== Creating and Quitting the Driver
 
-Most of the functions like `click`, `fill`, etc require a query term to discover an element on a page.
-For example:
+Etaoin comes with many options to create a WebDriver instance.
+
+TIP: As previously mentioned, we recommend the `with-<browser>` convention when you need proper cleanup.
+
+Let's say we want to create a chrome headless driver:
+
+// let's not pollute our main test-doc-block ns with these driver vars:
+//{:test-doc-blocks/test-ns user-guide-driver-creation-test}
+[source,clojure]
+----
+(require '[etaoin.api :as e])
+
+;; at the base we have:
+(def driver (e/boot-driver :chrome {:headless true}))
+;; do stuff
+(e/quit driver)
+
+;; This can also be expressed as:
+(def driver (e/chrome {:headless true}))
+;; do stuff
+(e/quit driver)
+
+;; Or...
+(def driver (e/chrome-headless))
+;; do stuff
+(e/quit driver)
+----
+
+The v2 API has ergonomic `with-<browser>` functions that handle cleanup nicely:
 
 [source,clojure]
 ----
-(click driver {:tag :button})
-(fill driver {:id "searchInput"} "Clojure")
+(require '[etaoin.api2 :as e2])
+
+(e2/with-chrome [driver {:headless true}]
+  (e/go driver "https://clojure.org"))
+
+(e2/with-chrome-headless [driver]
+  (e/go driver "https://clojure.org"))
 ----
 
-The library supports the following query types and values.
+Replace `chrome` with `firefox`, `edge` or `safari` for other variants.
+See link:{url-doc}[API docs] for details.
 
-=== Simple queries, XPath, CSS
+See <<parameters>> for all options available when creating a driver
+
+== Selecting Elements [[querying]]
+
+Queries (aka selectors) are used to select the elements on the page that Etaoin will interact with.
+
+[source,clojure]]
+----
+;; let's start anew by refreshing the page:
+(e/refresh driver)
+;; select the element with an html attribute id of 'uname' and fill it with text:
+(e/fill driver {:id "uname"} "Etaoin")
+;; select the first element with an html button tag and click on it:
+(e/click driver {:tag :button})
+----
+
+[TIP]
+====
+* A query returns a unique element identifier that is typically meaningful only as a selector to other functions it is passed to.
+* Many functions accept a query directly. For example:
++
+[source,clojure]]
+----
+;; specifying query directly
+(e/get-element-text driver {:tag :button})
+;; => "Submit Form"
+;; specifying the result of a query (notice the `-el` fn variant here)
+(e/get-element-text-el driver (e/query driver {:tag :button}))
+;; => "Submit Form"
+----
+====
+
+[TIP]
+====
+If a query does not find the element, an exception will be thrown.
+Use `exists?` to check if a query returns an element.
+
+[source,clojure]
+----
+(e/exists? driver {:tag :button})
+;; => true
+(e/exists? driver {:id "wont-find-me"})
+;; => false
+----
+====
+
+=== Simple Queries, XPath, CSS
 
 :xpath-sel: https://www.w3schools.com/xml/xpath_syntax.asp
 :css-sel: https://www.w3schools.com/cssref/css_selectors.asp
 
-* `:active` stands for the current active element.
-When opening Google page for example, it focuses the cursor on the main search input.
-So there is no need to click on in manually.
-Example:
+* `:active` finds the current active element.
+The Google page, for example, automatically places the focus on the main search input.
+So there is no need to click on it first:
 +
 [source,clojure]
 ----
-(fill driver :active "Let's search for something" keys/enter)
+(e/go driver "https://google.com")
+(e/fill driver :active "Let's search for something" k/enter)
 ----
 
-* any other keyword that indicates an element's ID.
-For Google page, it is `:lst-ib` or `"lst-ib"` (strings are also supported).
-The registry matters.
-Example:
+* any other keyword is translated to an html id attribute:
 +
 [source,clojure]
 ----
-(fill driver :lst-ib "What is the Matrix?" keys/enter)
+(e/go driver sample-page)
+(e/fill driver :uname "Etaoin" k/enter)
+;; alternatively you can:
+(e/fill driver {:id "uname"} "Etaoin Again" k/enter)
 ----
 
-* a string with an link:{xpath-sel}[XPath] expression.
-Be careful when writing them manually.
-Check the `Troubleshooting` section below.
-Example:
+* a string containing an link:{xpath-sel}[XPath] expression.
+(Be careful when writing XPath manually, see <<troubleshooting>>.)
+Here we find an `input` tag with an attribute `id` of `uname` and an attribute `name` of `username`:
 +
 [source,clojure]
 ----
-(fill driver ".//input[@id='lst-ib'][@name='q']" "XPath in action!" keys/enter)
+(e/refresh driver)
+(e/fill driver ".//input[@id='uname'][@name='username']" "XPath can be tricky")
+
+;; let's check if that worked as expected:
+(e/get-element-value driver :uname)
+;; => "XPath can be tricky"
 ----
 
-* a map with either `:xpath` or `:css` key with a string expression of corresponding syntax.
-Example:
+* a map with either `:xpath` or `:css` key with a string in corresponding syntax:
 +
 [source,clojure]
 ----
-(fill driver {:xpath ".//input[@id='lst-ib']"} "XPath selector" keys/enter)
-(fill driver {:css "input#lst-ib[name='q']"} "CSS selector" keys/enter)
+(e/refresh driver)
+(e/fill driver {:xpath ".//input[@id='uname']"} "XPath selector")
+(e/fill driver {:css "input#uname[name='username']"} " CSS selector")
+
+;; And here's what we should see in username input field now:
+(e/get-element-value driver :uname)
+;; => "XPath selector CSS selector"
 ----
 +
-See the link:{css-sel}[CSS selector] manual for more info.
+This link:{css-sel}[CSS selector reference] may be of help.
 
-=== Map syntax for querying
+=== Map Syntax Queries
 
-A query might be any other map that represents an XPath expression as data.
+A query can also be a map that represents an XPath expression as data.
 The rules are:
 
 * A `:tag` key represents a tag's name.
-It becomes `*` when not passed.
-* An `:index` key expands into the trailing `[x]` clause.
-Useful when you need to select a third row from a table for example.
+Defaults to `*`.
+* An `:index` key expands into the trailing XPath `[x]` clause.
+Useful when you need to select a third row from a table, for example.
 * Any non-special key represents an attribute and its value.
 * A special key has `:fn/` namespace and expands into something specific.
 
@@ -372,113 +527,157 @@ Examples:
 +
 [source,clojure]
 ----
-(query driver {:tag :div})
-;; expands into .//div
+(= (e/query driver {:tag :div})
+   ;; equivalent via xpath:
+   (e/query driver ".//div"))
+;; => true
 ----
 
-* find the n-th `div` tag
+* find the n-th (1-based) `div` tag
 +
 [source,clojure]
 ----
-(query driver {:tag :div :index 1})
-;; expands into .//div[1]
+(= (e/query driver {:tag :div :index 1})
+   ;; equivalent via xpath:
+   (e/query driver ".//div[1]"))
+;; => true
 ----
 
-* find the tag `a` with the class attribute equals to `active`
+* find the tag `a` where the class attribute equals to `active`
 +
 [source,clojure]
 ----
-  (query driver {:tag :a :class "active"})
-  ;; ".//a[@class=\"active\"]"
+(= (e/query driver {:tag :a :class "active"})
+   ;; equivalent xpath:
+   (e/query driver ".//a[@class='active']"))
 ----
 
 * find a form by its attributes:
 +
 [source,clojure]
 ----
-(query driver {:tag :form :method :GET :class :message})
-;; expands into .//form[@method="GET"][@class="message"]
+(= (e/query driver {:tag :form :method :GET :class :formy})
+   ;; equivalent in xpath:
+   (e/query driver ".//form[@method=\"GET\"][@class='formy']"))
 ----
 
 * find a button by its text (exact match):
 +
 [source,clojure]
 ----
-(query driver {:tag :button :fn/text "Press Me"})
-;; .//button[text()="Press Me"]
+(= (e/query driver {:tag :button :fn/text "Submit Form"})
+   ;; equivalent in xpath:
+   (e/query driver ".//button[text() = 'Submit Form']"))
 ----
 
-* find an nth element (`p`, `a`, whatever) with "download" text:
+* find an nth element (`p`, `div`, whatever, it does not matter) with "blarg" text:
 +
 [source,clojure]
 ----
-(query driver {:fn/has-text "download" :index 3})
-;; .//*[contains(text(), "download")][3]
+(e/get-element-text driver {:fn/has-text "blarg" :index 3})
+;; => "blarg in a p"
+
+;; equivalent in xpath:
+(e/get-element-text driver ".//*[contains(text(), 'blarg')][3]")
+;; => "blarg in a p"
 ----
 
-* find an element that has the following class:
+* find an element that includes a class:
 +
 [source,clojure]
 ----
-(query driver {:tag :div :fn/has-class "overlay"})
-;; .//div[contains(@class, "overlay")]
+(e/get-element-text driver {:tag :span :fn/has-class "class1"})
+;; => "blarg in a span"
+
+;; equivalent xpath:
+(e/get-element-text driver ".//span[contains(@class, 'class1')]")
+;; => "blarg in a span"
 ----
 
-* find an element that has the following domain in a href:
+* find an element that has the following domain in a `href`:
 +
 [source,clojure]
 ----
-(query driver {:tag :a :fn/link "google.com"})
-;; .//a[contains(@href, "google.com")]
+(e/get-element-text driver {:tag :a :fn/link "clojure.org"})
+;; => "link 3 (clojure.org)"
+
+;; equivalent xpath:
+(e/get-element-text driver ".//a[contains(@href, \"clojure.org\")]")
+;; => "link 3 (clojure.org)"
 ----
 
-* find an element that has the following classes at once:
+* find an element that includes all of the specified classes:
 +
 [source,clojure]
 ----
-(query driver {:fn/has-classes [:active :sticky :marked]})
-;; .//*[contains(@class, "active")][contains(@class, "sticky")][contains(@class, "marked")]
+(e/get-element-text driver {:fn/has-classes [:class2 :class3 :class5]})
+;; => "blarg in a div"
+
+;; equivalent in xpath:
+(e/get-element-text driver ".//*[contains(@class, 'class2')][contains(@class, 'class3')][contains(@class, 'class5')]")
+;; => "blarg in a div"
 ----
 
-* find the enabled/disabled input widgets:
+* find explicitly enabled/disabled input widgets:
 +
 [source,clojure]
 ----
-;; first input
-(query driver {:tag :input :fn/disabled true})
-;; .//input[@disabled=true()]
-(query driver {:tag :input :fn/enabled true})
-;; .//input[@enabled=true()]
+;; first enabled input
+(= (e/query driver {:tag :input :fn/enabled true})
+   ;; equivalent xpath:
+   (e/query driver ".//input[@enabled=true()]"))
+;; => true
 
-;; all inputs
-(query-all driver {:tag :input :fn/disabled true})
-;; .//input[@disabled=true()]
+;; first disabled input
+(= (e/query driver {:tag :input :fn/disabled true})
+   ;; equivalent xpath:
+   (e/query driver ".//input[@disabled=true()]"))
+;; => true
+
+;; return a vector of all disabled inputs
+(= (e/query-all driver {:tag :input :fn/disabled true})
+   ;; equivalent xpath:
+   (e/query-all driver ".//input[@disabled=true()]"))
+;; => true
 ----
 
-=== Vector syntax for querying
+=== Vector Syntax Queries
 
-A query might be a vector that consists from any expressions mentioned above.
-In such a query, every next term searches from a previous one recursively.
+A query can be a vector of any valid query expressions.
+For vector queries, every expression matches the output from the previous expression.
 
-A simple example:
+A simple, somewhat contrived, example:
 
 [source,clojure]
 ----
-(click driver [{:tag :html} {:tag :body} {:tag :a}])
+(e/click driver [{:tag :html} {:tag :body} {:tag :button}])
+;; our sample page shows form submits, did it work?
+(e/get-element-text driver :submit-count)
+;; => "1"
 ----
 
-You may combine both XPath and CSS expressions as well (pay attention at a leading dot in XPath expression:
+You may combine both XPath and CSS expressions
+
+TIP: Reminder: the leading dot in an XPath expression means starting at the current node
 
 [source,clojure]
 ----
-(click driver [{:tag :html} {:css "div.class"} ".//a[@class='download']"])
+;; under the html tag (using map query syntax),
+;;  under a div tag with a class that includes some-links (using css query),
+;;   click on a tag that has
+;;    a class attribute equal to active (using xpath syntax):
+(e/click driver [{:tag :html} {:css "div.some-links"} ".//a[@class='active']"])
+;; our sample page shows link clicks, did it work?
+(e/get-element-text driver :clicked)
+;; => "link 2 (active)"
 ----
 
-=== Advanced queries
+=== Advanced Queries
 
-==== Querying the _nth_ element matched
+==== Querying the _nth_ Element Matched
 
-Sometimes you may need to interact with the _nth_ element of a query, for instance when wanting to click on the second link in this example:
+Sometimes you may want to interact with the _nth_ element of a query.
+Maybe you want to click on the second link within:
 
 [source,html]
 ----
@@ -495,75 +694,114 @@ Sometimes you may need to interact with the _nth_ element of a query, for instan
 </ul>
 ----
 
-In this case you may either use the `:index` directive that is supported for XPath expressions like this:
+You can use the `:index` like so:
 
 [source,clojure]
 ----
-(click driver [{:tag :li :class :search-result :index 2} {:tag :a}])
+(e/click driver [{:tag :li :class :search-result :index 2} {:tag :a}])
+;; check click tracker from our sample page:
+(e/get-element-text driver :clicked)
+;; => "b"
 ----
 :nth-child: https://www.w3schools.com/CSSref/sel_nth-child.asp
 
 or you can use the link:{nth-child}[nth-child trick] with the CSS expression like this:
 
 [source,clojure]
+
 ----
-(click driver {:css "li.search-result:nth-child(2) a"})
+;; start page anew
+(e/refresh driver)
+(e/click driver {:css "li.search-result:nth-child(2) a"})
+(e/get-element-text driver :clicked)
+;; => "b"
 ----
 
 Finally it is also possible to obtain the _nth_ element directly by using `query-all`:
 
 [source,clojure]
 ----
-(click-el driver (nth (query-all driver {:css "li.search-result a"}) 2))
+;; start page anew
+(e/refresh driver)
+(e/click-el driver (nth (e/query-all driver {:css "li.search-result a"}) 1))
+(e/get-element-text driver :clicked)
+;; => "b"
 ----
 
-Note the use of `click-el` here, as `query-all` returns an element, not a selector that can be passed to `click` directly.
+[NOTE]
+====
+Notice:
 
-==== Getting elements like in a tree
+* The use of `click-el` here. The `query-all` function returns an element, not a selector that can be passed to `click` directly
+* The nth offset of 1 instead of 2. Clojure's nth is 0-based, and our search indexes are 1-based.
+====
 
-`query-tree` takes selectors and acts like a tree.
-Every next selector queries elements from the previous ones.
-The fist selector relies on find-elements, and the rest ones use find-elements-from
+==== Querying a Tree
+
+`query-tree` pipes selectors.
+Every next selector queries elements from the previous one.
+The fist selector finds elements from the root, subsquent selectors find elements downward from each of the previous found elements.
+
+Given the following HTML:
+[source,html]
+----
+<div id="query-tree-example">
+  <div id="one">
+    <a href="#">a1</a>
+    <a href="#">a2</a>
+    <a href="#">a3</a>
+  </div>
+  <div id="two">
+    <a href="#">a4</a>
+    <a href="#">a5</a>
+    <a href="#">a6</a>
+  </div>
+  <div id="three">
+    <a href="#">a7</a>
+    <a href="#">a8</a>
+    <a href="#">a9</a>
+  </div>
+</div>
+----
+
+The following query will find a vector of `div` tags, then return a set of all `a` tags under those `div` tags:
 
 [source,clojure]
 ----
-  (query-tree driver {:tag :div} {:tag :a})
+(->> (e/query-tree driver :query-tree-example {:tag :div} {:tag :a})
+     (map #(e/get-element-text-el driver %))
+     sort)
+;; => ("a1" "a2" "a3" "a4" "a5" "a6" "a7" "a8" "a9")
 ----
 
-means
+=== Interacting with Queried Elements
+
+To interact with elements found via a `query` or `query-all` function call you have to pass the query result to either `click-el` or `fill-el` (note the `-el` suffix):
 
 [source,clojure]
 ----
-  {:tag :div} -> [div1 div2 div3]
-  div1 -> [a1 a2 a3]
-  div2 -> [a4 a5 a6]
-  div3 -> [a7 a8 a9]
+(e/click-el driver (first (e/query-all driver {:tag :a})))
 ----
 
-so the result will be `[a1 ...  a9]`
-
-=== Interacting with queried elements
-
-To interact with elements found via a query you have to pass the query result to either `click-el` or `fill-el`:
+You can collect elements into a vector and arbitrarily interact with them at any time:
 
 [source,clojure]
 ----
-(click-el driver (first (query-all driver {:tag :a})))
+(e/refresh driver)
+(def elements (e/query-all driver {:tag :input :type :text :fn/disabled false}))
+
+(e/fill-el driver (first elements) "This is a test")
+(e/fill-el driver (rand-nth elements) "I like tests!")
 ----
 
-So you may collect elements into a vector and arbitrarily interact with them at any time:
+== Interactions
 
-[source,clojure]
-----
-(def elements (query-all driver {:tag :input :type :text})
+Some basic interactions are covered under <<querying>>, here we go into other types of interactions and more detail.
 
-(fill-el driver (first elements) "This is a test")
-(fill-el driver (rand-nth elements) "I like tests!")
-----
+=== Emulate how a Real Person Might Type
 
-== Emulation of human input
-
-For the purpose of emulating human input, you can use the `fill-human` function.
+Real people type slowly and make mistakes.
+To emulate these characteristics, you can use the `fill-human` function.
 The following options are enabled by default:
 
 [source,clojure]
@@ -572,35 +810,38 @@ The following options are enabled by default:
  :pause-max    0.2} ;; max typing delay in seconds
 ----
 
-and you can redefine them:
+which you can choose to override if you wish:
 
 [source,clojure]
 ----
-(fill-human driver q text {:mistake-prob 0.5
-                           :pause-max 1})
+(e/refresh driver)
+(e/fill-human driver :uname "soslowsobad"
+              {:mistake-prob 0.5
+               :pause-max 1})
 
-;; or just use default opts by omitting them
-(fill-human driver q text)
+;; or just use default options by omitting them
+(e/fill-human driver :uname " typing human defaults")
 ----
 
-for multiple input with human emulation, use `fill-human-multi`
+For multiple inputs, use `fill-human-multi`
 
 [source,clojure]
 ----
-(fill-human-multi driver {:login "login"
-                          :pass "password"
-                          :textarea "some text"}
-                         {:mistake-prob 0.5
-                          :pause-max 1})
+(e/refresh driver)
+(e/fill-human-multi driver {:uname "login"
+                            :pw "password"
+                            :text "some text"}
+                           {:mistake-prob 0.1
+                            :pause-max 0.1})
 ----
 
-== Mouse clicks
+=== Mouse Clicks
 
 The `click` function triggers the left mouse click on an element found by a query term:
 
 [source,clojure]
 ----
-(click driver {:tag :button})
+(e/click driver {:tag :button})
 ----
 
 The `click` function uses only the first element found by the query, which sometimes leads to clicking on the wrong items.
@@ -609,61 +850,484 @@ It acts the same but raises an exception when querying the page returns multiple
 
 [source,clojure]
 ----
-(click-single driver {:tag :button :name "search"})
+(e/click-single driver {:tag :button :name "submit"})
 ----
 
-A double click is used rarely in web yet is possible with the `double-click` function (Chrome, Phantom.js):
+Although double-clicking is rarely purposefully employed on web sites, some naive users might think it is the correct way to click on a button or link.
+
+A double click can be simulated with `double-click` function (Chrome, Phantom.js).
+It can be used, for example, to check your handling of disallowing multiple form submissions.
 
 [source,clojure]
 ----
-(double-click driver {:tag :dbl-click-btn})
+(e/double-click driver {:tag :button :name "submit"})
 ----
 
-There is also a bunch of "blind" clicking functions.
+There are also "blind" clicking functions.
 They trigger mouse clicks on the current mouse position:
 
 [source,clojure]
 ----
-(left-click driver)
-(middle-click driver)
-(right-click driver)
+(e/left-click driver)
+(e/middle-click driver)
+(e/right-click driver)
 ----
 
-Another bunch of functions do the same but move the mouse pointer to a specified element before clicking on them:
+Another set of functions do the same but move the mouse pointer to a specified element before clicking on them:
 
 [source,clojure]
 ----
-(left-click-on driver {:tag :img})
-(middle-click-on driver {:tag :img})
-(right-click-on driver {:tag :img})
+(e/left-click-on driver {:tag :a})
+(e/middle-click-on driver {:tag :a})
+(e/right-click-on driver {:tag :a})
 ----
 
-A middle mouse click is useful when opening a link in a new background tab.
+A middle mouse click is useful to open a link in a new background tab.
 The right click sometimes is used to imitate a context menu in web applications.
 
-== Actions
+=== Keyboard Chords
 
-The library supports link:{actions}[Webdriver Actions].
-In general, actions are commands describing virtual input devices.
+There is an option to input a series of keys simultaneously.
+This useful to imitate holding a system key like Control, Shift or whatever when typing.
+
+The namespace `etaoin.keys` includes key constants as well as a set of functions related to keyboard input.
 
 [source,clojure]
 ----
-{:actions [{:type    "key"
-            :id      "some name"
-            :actions [{:type "keyDown" :value cmd}
-                      {:type "keyDown" :value "a"}
-                      {:type "keyUp" :value "a"}
-                      {:type "keyUp" :value cmd}
-                      {:type "pause" :duration 100}]}
-           {:type       "pointer"
-            :id         "UUID or some name"
-            :parameters {:pointerType "mouse"}
-            :actions    [{:type "pointerMove" :origin "pointer" :x 396 :y 323}
-                         ;; double click
-                         {:type "pointerDown" :duration 0 :button 0}
-                         {:type "pointerUp" :duration 0 :button 0}
-                         {:type "pointerDown" :duration 0 :button 0}
-                         {:type "pointerUp" :duration 0 :button 0}]}]}
+(require '[etaoin.keys :as k])
+----
+
+A quick example of entering ordinary characters while holding Shift:
+
+[source,clojure]
+----
+(e/refresh driver)
+(e/fill-active driver (k/with-shift "caps is great"))
+(e/get-element-value driver :active)
+;; => "CAPS IS GREAT"
+----
+
+The main input gets populated with "CAPS IS GREAT".
+Now maybe you'd like to delete the last word.
+Assuming you are using Chrome, this is done by pressing backspace holding Alt.
+Let's do that:
+
+[source,clojure]
+----
+(e/fill-active driver (k/with-alt k/backspace))
+(e/get-element-value driver :active)
+;; => "CAPS IS "
+----
+
+Consider a more complex example which repeats real user behaviour.
+You'd like to delete everything from the input.
+First, you move the cursor to the very beginning of the input field.
+Then move it to the end holding shift so everything gets selected.
+Finally, you press delete to clear the selected text:
+
+[source,clojure]
+----
+(e/fill-active driver k/home (k/with-shift k/end) k/delete)
+(e/get-element-value driver :active)
+;; => ""
+----
+
+There are also `with-ctrl` and `with-command` functions that act as you would expect.
+
+NOTE: Pay attention, these functions do not apply to the global browser's shortcuts.
+For example, neither "Command + R" nor "Command + T" reload the page or open a new tab.
+
+All the `etaoin.keys/with-*` functions are just wrappers upon the `etaoin.keys/chord` function that might be used for complex cases.
+
+=== File Uploading
+
+Clicking on a file input button opens an OS-specific dialog that you are not allowed to interact with using WebDriver protocol.
+Use the `upload-file` function to attach a local file to a file input widget.
+The function takes a selector that points to a file input and either path as a string or a native `java.io.File` instance.
+An exception will be thrown if the local file is not found.
+
+[source,clojure]
+----
+;; open a web page that serves uploaded files
+(e/go driver "http://nervgh.github.io/pages/angular-file-upload/examples/simple/")
+
+;; bind element selector to variable; you may also specify an id, class, etc
+(def file-input {:tag :input :type :file})
+
+;; upload a file form your system to the first file input
+(def my-file "env/test/resources/html/drag-n-drop/images/document.png")
+(e/upload-file driver file-input my-file)
+
+;; or pass a native Java File object:
+(require '[clojure.java.io :as io])
+(def my-file (io/file "env/test/resources/html/drag-n-drop/images/document.png"))
+(e/upload-file driver file-input my-file)
+----
+
+=== Scrolling
+
+Etaoin includes functions to scroll the web page.
+
+The most important one, `scroll-query` jumps the the first element found with the query term:
+
+[source,clojure]
+----
+(e/go driver sample-page)
+;; scroll to the 5th h2 heading
+(e/scroll-query driver {:tag :h2} {:index 5})
+
+;; and back up to first h1
+(e/scroll-query driver {:tag :h1})
+----
+
+To jump to the absolute pixel positions, use `scroll`:
+
+[source,clojure]
+----
+(e/scroll driver 100 600)
+;; or pass a map with x and y keys
+(e/scroll driver {:x 100 :y 600})
+----
+
+To scroll relatively by pixels, use `scroll-by` with offset values:
+
+[source,clojure]
+----
+;; scroll right by 100 and down by 300
+(e/scroll-by driver 100 300)
+;; use map syntax to scroll left by 50 and up by 200
+(e/scroll-by driver {:x -50 :y -200})
+----
+
+There are two convenience functions to scroll vertically to the top or bottom of the page:
+
+[source,clojure]
+----
+(e/scroll-bottom driver) ;; you'll see the footer...
+(e/scroll-top driver)    ;; ...and the header again
+----
+
+The following functions scroll the page in all directions:
+
+[source,clojure]
+----
+(e/scroll driver [0 0])     ;; let's start at top left
+
+(e/scroll-down driver 200)  ;; scrolls down by 200 pixels
+(e/scroll-down driver)      ;; scrolls down by the default (100) number of pixels
+
+(e/scroll-up driver 200)    ;; the same, but scrolls up...
+(e/scroll-up driver)
+
+(e/scroll-right driver 200) ;; ... and right
+(e/scroll-right driver)
+
+(e/scroll-left driver 200)  ;; ...left
+(e/scroll-left driver)
+
+----
+
+NOTE: All scroll actions are carried out via Javascript.
+Ensure your browser has it enabled.
+
+=== Working with frames and iframes
+
+You can only interact with items within an individual frame or iframe by first swithing to them.
+
+Say you have an HTML layout like this:
+
+[source,html]
+----
+<iframe id="frame1" src="...">
+  <p id="in-frame1">In frame2 paragraph</p>
+  <iframe id="frame2" src="...">
+    <p id="in-frame2">In frame2 paragraph</p>
+  </iframe>
+</iframe>
+----
+
+Let's explore switching to `:frame1`.
+
+[source,clojure]
+----
+(e/go driver sample-page)
+;; we start in the main page, we can't see inside frame1:
+(e/exists? driver :in-frame1)
+;; => false
+
+;; switch context to frame with id of frame1:
+(e/switch-frame driver :frame1)
+
+;; now we can interact with elements in frame1:
+(e/exists? driver :in-frame1)
+;; => true
+(e/get-element-text driver :in-frame1)
+;; => "In frame1 paragraph"
+
+;; switch back to top frame (the main page)
+(e/switch-frame-top driver)
+----
+
+To reach nested frames, you can dig down like so:
+
+[source,clojure]
+----
+;; switch to the first top-level iframe with the main page: frame1
+(e/switch-frame-first driver)
+;; downward to the first iframe with frame1: frame2
+(e/switch-frame-first driver)
+(e/get-element-text driver :in-frame2)
+;; => "In frame2 paragraph"
+;; back up to frame1
+(e/switch-frame-parent driver)
+;; back up to main page
+(e/switch-frame-parent driver)
+----
+
+You can also use the `with-frame` macro to temporarily switch to a target frame, do some work, returning its last expression, all while preserving your original frame context.
+
+[source,clojure]
+----
+(e/with-frame driver {:id :frame1}
+  (e/with-frame driver {:id :frame2}
+    (e/get-element-text driver :in-frame2)))
+;; => "In frame2 paragraph"
+----
+
+=== Executing Javascript
+
+Use `js-execute` to evaluate a Javascript code in the browser:
+
+[source,clojure]
+----
+(e/js-execute driver "alert('Hello from Etaoin!')")
+(e/dismiss-alert driver)
+----
+
+Pass any additional parameters into the call inside a script with the `arguments` array-like object.
+[source,clojure]
+----
+(e/js-execute driver "alert(arguments[2].foo)" 1 false {:foo "hello again!"})
+(e/dismiss-alert driver)
+----
+
+We have passed 3 arguments:
+
+. `1`
+. `false`
+. `{:foo "hello again!}` which is automatically converted to JSON `{"foo": "hello again!"}`
+
+The alert then presents the `foo` field of the 3rd (index 2) argument, which is `"hello again!"`.
+
+To return any data to Clojure, add `return` into your script:
+
+[source,clojure]
+----
+(e/js-execute driver "return {foo: arguments[2].foo, bar: [1, 2, 3]}"
+                     ;; same args as previous example:
+                     1 false {:foo "hello again!"})
+;; => {:bar [1 2 3], :foo "hello again!"}
+----
+
+Notice that the JSON has been automatically converted to edn.
+
+==== Asynchronous Scripts
+
+If your script performs AJAX requests or operates on `setTimeout` or any other async strategies, you cannot just `return` the result.
+Instead, a special callback must be called against the data you'd like to resolve.
+The WebDriver passes this callback by adding it as the last argument for your script.
+
+Example:
+
+[source,clojure]
+----
+(e/js-async
+  driver
+  "var args = arguments; // preserve the global args
+  // WebDriver added the callback as the last arg, we grab it here
+  var callback = args[args.length-1];
+  setTimeout(function() {
+    // We call the WebDriver callback passing with what we want it to return
+    // In this case we pass we chose to return 42 from the arg we passed in
+    callback(args[0].foo.bar.baz);
+  },
+  1000);"
+  {:foo {:bar {:baz 42}}})
+;; => 42
+----
+
+If you'd like to override the default script timeout, you can do so for the WebDriver session:
+
+[source,clojure]
+----
+;; optionally save the current value for later restoration
+(def orig-script-timeout (e/get-script-timeout driver))
+(e/set-script-timeout driver 5) ;; in seconds
+;; do some stuff
+(e/set-script-timeout driver orig-script-timeout)
+----
+
+or for a block of code via `with-script-timeout`:
+
+//:test-doc-blocks/skip
+[source,clojure]
+----
+(e/with-script-timeout driver 30
+  (e/js-async driver "var callback = arguments[arguments.length-1];
+                      //some long operation here
+                      callback('phew,done!');"))
+;; => "phew,done!"
+----
+
+=== Wait Functions
+
+The main difference between a program and a human being is that the first one operates very fast.
+A computer operates so fast, that sometimes a browser cannot render new HTML in time.
+After each action, you might consider including a `wait-<something>` function that polls a browser until the predicate evaluates into true.
+Or just `(wait <seconds>)` if you don't care about optimization.
+
+The `with-wait` macro might be helpful when you need to prepend each action with `(wait n)`.
+For example, the following form:
+
+[source,clojure]
+----
+(e/with-wait 1 
+  (e/refresh driver)
+  (e/fill driver :uname "my username")
+  (e/fill driver :text "some text"))
+----
+
+is executed something along the lines of:
+
+[source,clojure]
+----
+(e/wait 1)
+(e/refresh driver)
+(e/wait 1)
+(e/fill driver :uname "my username")
+(e/wait 1)
+(e/fill driver :text "some text")
+----
+
+and thus returns the result of the last form of the original body.
+
+The `(doto-wait n driver & body)` acts like the standard `doto` but prepends each form with `(wait n)`.
+The above example re-expressed with `doto-wait`:
+
+[source,clojure]
+----
+(e/doto-wait 1 driver
+  (e/refresh)
+  (e/fill :uname "my username")
+  (e/fill :text "some text"))
+----
+
+This is effectively the same as:
+
+[source,clojure]
+----
+(doto driver
+  (e/wait 1)
+  (e/refresh)
+  (e/wait 1)
+  (e/fill :uname "my username")
+  (e/wait 1)
+  (e/fill :text "some text"))
+----
+
+In addition to `with-wait` and `do-wait` there are a number of waiting functions: `wait-visible`, `wait-has-alert`, `wait-predicate`, etc (see the full list in the link:{url-doc}/CURRENT/api/etaoin.api#wait[API docs].
+They accept default timeout/interval values that can be redefined using the `with-wait-timeout` and `with-wait-interval` macros, respectively.
+They all throw if the wait timeout is exceeded.
+
+[source,clojure]
+----
+(e/with-wait-timeout 15 ;; time in seconds
+  (doto driver
+    (e/refresh)
+    (e/wait-visible {:id :last-section})
+    (e/click {:tag :a})
+    (e/wait-has-text :clicked "link 1")))
+----
+
+Wait text:
+
+* `wait-has-text` waits until an element has text anywhere inside it (including inner HTML).
++
+[source,clojure]
+----
+(e/click driver {:tag :a})
+(e/wait-has-text driver :clicked "link 1")
+----
+
+* `wait-has-text-everywhere` like `wait-has-text` but searches for text across the entire page
++
+[source,clojure]
+----
+(e/wait-has-text-everywhere driver "ipsum")
+----
+
+=== Load Strategy [[load-strategy]]
+
+When you navigate to a page, the driver waits until the whole page has been completely loaded.
+What's fine in most cases, but doesn't reflect the way human beings interact with the Internet.
+
+Change this default behavior with the `:load-strategy` option:
+
+* `:normal` (the default) wait for full page load (everything, include images, etc)
+* `:none` don't wait at all
+* `:eager` wait for only DOM content to load
+
+For example, the default `:normal` strategy:
+
+[source,clojure]
+----
+(e2/with-chrome [driver]
+  (e/go driver sample-page)
+  ;; by default you'll hang on this line until the page loads
+  ;; (do-something)
+)
+----
+
+Load strategy option of `:none`:
+
+[source,clojure]
+----
+(e2/with-chrome [driver {:load-strategy :none}]
+  (e/go driver sample-page)
+  ;; no pause, no waiting, acts immediately
+  ;; (do-something)
+)
+----
+
+The `:eager` option only works with Firefox at the moment.
+
+=== Actions
+
+Etaoin supports link:{actions}[Webdriver Actions].
+They are described as "virtual input devices".
+They act as little device input scripts that run simultaneously.
+
+Here, in raw form, we have an example of two actions.
+One controls the keyboard, the other the pointer (mouse).
+
+[source,clojure]
+----
+;; a keyboard input
+{:type    "key"
+ :id      "some name"
+ :actions [{:type "keyDown" :value "a"}
+           {:type "keyUp" :value "a"}
+           {:type "pause" :duration 100}]}
+;; some pointer input
+{:type       "pointer"
+ :id         "UUID or some name"
+ :parameters {:pointerType "mouse"}
+ :actions    [{:type "pointerMove" :origin "pointer" :x 396 :y 323}
+              ;; double click
+              {:type "pointerDown" :duration 0 :button 0}
+              {:type "pointerUp" :duration 0 :button 0}
+              {:type "pointerDown" :duration 0 :button 0}
+              {:type "pointerUp" :duration 0 :button 0}]}
 ----
 
 You can create a map manually and send it to the `perform-actions` method:
@@ -672,257 +1336,854 @@ You can create a map manually and send it to the `perform-actions` method:
 ----
 (def keyboard-input {:type    "key"
                      :id      "some name"
-                     :actions [{:type "keyDown" :value cmd}
-                               {:type "keyDown" :value "a"}
-                               {:type "keyUp" :value "a"}
-                               {:type "keyUp" :value cmd}
+                     :actions [{:type "keyDown" :value "e"}
+                               {:type "keyUp" :value "e"}
+                               {:type "keyDown" :value "t"}
+                               {:type "keyUp" :value "t"}
+                               ;; duration is in ms
                                {:type "pause" :duration 100}]})
-
-(perform-actions driver keyboard-input)
+;; refresh so that we'll be at the active input field
+(e/refresh driver)
+;; perform our keyboard input action
+(e/perform-actions driver keyboard-input)
 ----
 
-or use wrappers.
-First you need to create a virtual input devices, for example:
+Or you might choose to use Etaoin's action helpers.
+First you create the virtual input device:
 
 [source,clojure]
 ----
-(def keyboard (make-key-input))
+(def keyboard (e/make-key-input))
 ----
 
-and then fill it with the necessary actions:
+and then fill it with the actions:
 
 [source,clojure]
 ----
 (-> keyboard
-    (add-key-down keys/shift-left)
-    (add-key-down "a")
-    (add-key-up "a")
-    (add-key-up keys/shift-left))
+    (e/add-key-down k/shift-left)
+    (e/add-key-down "a")
+    (e/add-key-up "a")
+    (e/add-key-up k/shift-left))
 ----
 
-extended example:
+Here's a slightly larger working annotated example:
 
 [source,clojure]
 ----
-(let [driver       (chrome)
-      _            (go driver "https://google.com")
-      search-box   (query driver {:name :q})
-      mouse        (-> (make-mouse-input)
-                       (add-pointer-click-el search-box))
-      keyboard     (-> (make-key-input)
-                       add-pause
-                       (with-key-down keys/shift-left
-                         (add-key-press "e"))
-                       (add-key-press "t")
-                       (add-key-press "a")
-                       (add-key-press "o")
-                       (add-key-press "i")
-                       (add-key-press "n")
-                       (add-key-press keys/enter))]
-  (perform-actions driver keyboard mouse)
-  (quit driver))
+;; virtual inputs run simultaneously so we'll create a little helper to generate n pauses
+(defn add-pauses [input n]
+  (->> (iterate e/add-pause input)
+       (take (inc n))
+       last))
+
+(let [username (e/query driver :uname)
+      submit-button (e/query driver {:tag :button})
+      mouse (-> (e/make-mouse-input)
+                ;; click on username
+                (e/add-pointer-click-el
+                  username k/mouse-left)
+                ;; pause 10 clicks to allow keyboard action to enter username
+                ;; (key up and down for each of keypress for etaoin)
+                (add-pauses 10)
+                ;; click on submit button
+                (e/add-pointer-click-el
+                  submit-button k/mouse-left))
+      keyboard (-> (e/make-key-input)
+                   ;; pause 2 ticks to allow mouse action to first click on username
+                   ;; (move to username element + click on it)
+                   (add-pauses 2)
+                   (e/with-key-down k/shift-left
+                     (e/add-key-press "e"))
+                   (e/add-key-press "t")
+                   (e/add-key-press "a")
+                   (e/add-key-press "o")
+                   (e/add-key-press "i")
+                   (e/add-key-press "n")) ]
+  (e/perform-actions driver keyboard mouse))
 ----
 
-To clear the state of virtual input devices, release all pressed keys etc, use the `release-actions` method:
+To clear the state of virtual input devices, release all currently pressed keys etc, use the `release-actions` method:
 
 [source,clojure]
 ----
-(release-actions driver)
+(e/release-actions driver)
 ----
 
-== File uploading
+== Capturing Screenshots
 
-Clicking on a file input button opens an OS-specific dialog that you are not allowed to interact with using WebDriver protocol.
-Use the `upload-file` function to attach a local file to a file input widget.
-The function takes a selector that points to a file input and either a full path as a string or a native `java.io.File` instance.
-The file should exist or you'll get an exception otherwise.
-Usage example:
+Calling the `screenshot` function dumps the current visible page into a PNG image file on your disk.
+Specify any absolute or relative path.
+Specify a string:
 
 [source,clojure]
 ----
-(def driver (chrome))
+(e/screenshot driver "target/etaoin-play/page.png")
+----
 
-;; open a web page that serves uploaded files
-(go driver "http://nervgh.github.io/pages/angular-file-upload/examples/simple/")
+or a `File` object:
 
-;; bound selector to variable; you may also specify an id, class, etc
-(def input {:tag :input :type :file})
-
-;; upload an image with the first one file input
-(def my-file "/Users/ivan/Downloads/sample.png")
-(upload-file driver input my-file)
-
-;; or pass a native Java object:
+[source,clojure]
+----
 (require '[clojure.java.io :as io])
-(def my-file (io/file "/Users/ivan/Downloads/sample.png"))
-(upload-file driver input my-file)
+(e/screenshot driver (io/file "target/etaoin-play/test.png"))
 ----
 
-== Screenshots
+=== Screenshots for Specific Elements
 
-Calling a `screenshot` function dumps the current page into a PNG image on your disk:
+With Firefox and Chrome, you can also capture a single element within a page, say a div, an input widget or whatever.
+It doesn't work with other browsers as this time.
 
 [source,clojure]
 ----
-(screenshot driver "page.png")             ;; relative path
-(screenshot driver "/Users/ivan/page.png") ;; absolute path
+(e/screenshot-element driver {:tag :form :class :formy} "target/etaoin-play/form-element.png")
 ----
 
-A native Java File object is also supported:
+=== Screenshots after each form
+
+Use `with-screenshots` to take a screenshot to the specified directory after each form is executed in the code block.
+The filenaming convention is `<webdriver-name>-<milliseconds-since-1970>.png`
 
 [source,clojure]
 ----
-;; when imported as `[clojure.java.io :as io]`
-(screenshot driver (io/file "test.png"))
+(require '[clojure.java.io :as io])
 
-;; native object
-(screenshot driver (java.io.File. "test-native.png"))
+(e/refresh driver)
+(.mkdirs (io/file "target/etaoin-play/saved-screenshots"))
+(e/with-screenshots driver "target/etaoin-play/saved-screenshots"
+  (e/fill driver :uname "et")
+  (e/fill driver :uname "ao")
+  (e/fill driver :uname "in"))
 ----
 
-=== Screening elements
+this is equivalent to something along the lines of:
 
-With Firefox and Chrome, you may capture not the whole page but a single element, say a div, an input widget or whatever.
-It doesn't work with other browsers for now.
+[source,clojure]
+----
+(require '[clojure.java.io :as io])
+
+(e/refresh driver)
+(.mkdirs (io/file "target/etaoin-play/saved-screenshots"))
+(e/fill driver :uname "et")
+(e/screenshot driver "target/etaoin-play/saved-screenshots/chrome-1.png")
+(e/fill driver :uname "ao")
+(e/screenshot driver "target/etaoin-play/saved-screenshots/chrome-2.png")
+(e/fill driver :uname "in")
+(e/screenshot driver "target/etaoin-play/saved-screenshots/chrome-3.png")
+----
+
+== Peeking deeper
+
+Sometimes it is useful to peek a little deeper.
+
+=== Reading a Browser's Console Logs [[console-logs]]
+
+Function `get-logs` returns the browser's console logs as a vector of maps.
+Each map has the following structure:
+
+// note that we do not verify get-logs output with test-doc-blocks by omitting =>
+[source,clojure]
+----
+(e/js-execute driver "console.log('foo')")
+(e/get-logs driver)
+;; [{:level :info,
+;;   :message "console-api 2:32 \"foo\"",
+;;   :source :console-api,
+;;   :timestamp 1654358994253,
+;;   :datetime #inst "2022-06-04T16:09:54.253-00:00"}]
+
+;; on the 2nd call, for chrome, we'll find the logs empty
+(e/get-logs driver)
+;; => []
+----
+
+Currently, logs are available in Chrome and Phantom.js only.
+The message text and the source type will vary by browser vendor.
+Chrome wipes the logs once they have been read.
+Phantom.js wipes the logs when the page location changes.
+
+=== DevTools: Tracking HTTP Requests, XHR (Ajax)
+
+You can trace events which come from the DevTools panel.
+This means that everything you see in the developer console now is available through the Etaoin API.
+This currenty only works for Google Chrome.
+
+To start a driver with devtools support enabled specify a `:dev` map.
+
+//let's put this drier in its own namespace
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+(require '[etaoin.api2 :as e2])
+
+(e2/with-chrome [driver {:dev {}}]
+  ;; do some stuff
+)
+----
+
+The value must not be a map (not `nil`).
+When `:dev` an empty map, the following defaults are used.
+
+[source,clojure]
+----
+{:perf
+ {:level :all
+  :network? true
+  :page? false
+  :categories [:devtools.network]
+  :interval 1000}}
+----
+
+We'll work with a driver that enables everything:
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+(require '[etaoin.api :as e])
+
+(def driver (e/chrome {:dev
+                       {:perf
+                        {:level :all
+                         :network? true
+                         :page? true
+                         :interval 1000
+                         :categories [:devtools
+                                      :devtools.network
+                                      :devtools.timeline]}}}))
+----
+
+Under the hood, Etaoin sets up a special `perfLoggingPrefs` dictionary inside the `chromeOptions` object.
+
+Now that your browser is accumulating these events, you can read them using a special `dev` namespace.
+
+The results will be different when you try this, but here's what I experienced:
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+(require '[etaoin.dev :as dev])
+
+(e/go driver "https://google.com")
+
+(def reqs (dev/get-requests driver))
+
+;; reqs is a vector of maps
+(count reqs)
+;; 23
+
+;; what were the request types?
+(frequencies (map :type reqs))
+;; {:script 6,
+;;  :other 2,
+;;  :xhr 4,
+;;  :image 5,
+;;  :stylesheet 1,
+;;  :ping 3,
+;;  :document 1,
+;;  :manifest 1}
+
+;; Interesting, we've got Js requests, images, AJAX and other stuff
+----
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+;; let's take a peek at the last image:
+(last (filter #(= :image (:type %)) reqs))
+;;    {:state 4,
+;;     :id "14535.6",
+;;     :type :image,
+;;     :xhr? false,
+;;     :url
+;;     "https://www.google.com/images/searchbox/desktop_searchbox_sprites318_hr.webp",
+;;     :with-data? nil,
+;;     :request
+;;     {:method :get,
+;;      :headers
+;;      {:Referer "https://www.google.com/?gws_rd=ssl",
+;;       :sec-ch-ua-full-version-list
+;;       "\" Not A;Brand\";v=\"99.0.0.0\", \"Chromium\";v=\"102.0.5005.61\", \"Google Chrome\";v=\"102.0.5005.61\"",
+;;       :sec-ch-viewport-width "1200",
+;;       :sec-ch-ua-platform-version "\"10.15.7\"",
+;;       :sec-ch-ua
+;;       "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"102\", \"Google Chrome\";v=\"102\"",
+;;       :sec-ch-ua-platform "\"macOS\"",
+;;       :sec-ch-ua-full-version "\"102.0.5005.61\"",
+;;       :sec-ch-ua-wow64 "?0",
+;;       :sec-ch-ua-model "",
+;;       :sec-ch-ua-bitness "\"64\"",
+;;       :sec-ch-ua-mobile "?0",
+;;       :sec-ch-dpr "1",
+;;       :sec-ch-ua-arch "\"x86\"",
+;;       :User-Agent
+;;       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
+;;     :response
+;;     {:status nil,
+;;      :headers
+;;      {:date "Sat, 04 Jun 2022 00:11:36 GMT",
+;;       :x-xss-protection "0",
+;;       :x-content-type-options "nosniff",
+;;       :server "sffe",
+;;       :cross-origin-opener-policy-report-only
+;;       "same-origin; report-to=\"static-on-bigtable\"",
+;;       :last-modified "Wed, 22 Apr 2020 22:00:00 GMT",
+;;       :expires "Sat, 04 Jun 2022 00:11:36 GMT",
+;;       :cache-control "private, max-age=31536000",
+;;       :content-length "660",
+;;       :report-to
+;;       "{\"group\":\"static-on-bigtable\",\"max_age\":2592000,\"endpoints\":[{\"url\":\"https://csp.withgoogle.com/csp/report-to/static-on-bigtable\"}]}",
+;;       :alt-svc
+;;       "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+;;       :cross-origin-resource-policy "cross-origin",
+;;       :content-type "image/webp",
+;;       :accept-ranges "bytes"},
+;;      :mime "image/webp",
+;;      :remote-ip "142.251.41.68"},
+;;     :done? true}
+----
+
+TIP: The details of these responses come from Chrome and are subject to changes to Chrome.
+
+Since we're mostly interested in AJAX requests, there is a function `get-ajax` that does the same but filters XHR requests:
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+;; refresh to fill the logs again
+(e/go driver "https://google.com")
+(e/wait 2) ;; give ajax requests a chance to finish
+
+(last (dev/get-ajax driver))
+;; {:state 4,
+;;  :id "14535.59",
+;;  :type :xhr,
+;;  :xhr? true,
+;;  :url
+;;    "https://www.google.com/complete/search?q&cp=0&client=gws-wiz&xssi=t&hl=en-CA&authuser=0&psi=OtuaYq-xHNeMtQbkjo6gBg.1654315834852&nolsbt=1&dpr=1",
+;;  :with-data? nil,
+;;  :request
+;;  {:method :get,
+;;   :headers
+;;   {:Referer "https://www.google.com/",
+;;    :sec-ch-ua-full-version-list
+;;    "\" Not A;Brand\";v=\"99.0.0.0\", \"Chromium\";v=\"102.0.5005.61\", \"Google Chrome\";v=\"102.0.5005.61\"",
+;;    :sec-ch-viewport-width "1200",
+;;    :sec-ch-ua-platform-version "\"10.15.7\"",
+;;    :sec-ch-ua
+;;    "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"102\", \"Google Chrome\";v=\"102\"",
+;;    :sec-ch-ua-platform "\"macOS\"",
+;;    :sec-ch-ua-full-version "\"102.0.5005.61\"",
+;;    :sec-ch-ua-wow64 "?0",
+;;    :sec-ch-ua-model "",
+;;    :sec-ch-ua-bitness "\"64\"",
+;;    :sec-ch-ua-mobile "?0",
+;;    :sec-ch-dpr "1",
+;;    :sec-ch-ua-arch "\"x86\"",
+;;    :User-Agent
+;;    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
+;;  :response
+;;  {:status nil,
+;;   :headers
+;;   {:bfcache-opt-in "unload",
+;;    :date "Sat, 04 Jun 2022 04:10:35 GMT",
+;;    :content-disposition "attachment; filename=\"f.txt\"",
+;;    :x-xss-protection "0",
+;;    :server "gws",
+;;    :expires "Sat, 04 Jun 2022 04:10:35 GMT",
+;;    :accept-ch
+;;    "Sec-CH-Viewport-Width, Sec-CH-Viewport-Height, Sec-CH-DPR, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version, Sec-CH-UA-Arch, Sec-CH-UA-Model, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version-List, Sec-CH-UA-WoW64",
+;;    :cache-control "private, max-age=3600",
+;;    :report-to
+;;    "{\"group\":\"gws\",\"max_age\":2592000,\"endpoints\":[{\"url\":\"https://csp.withgoogle.com/csp/report-to/gws/cdt1\"}]}",
+;;    :x-frame-options "SAMEORIGIN",
+;;    :strict-transport-security "max-age=31536000",
+;;    :content-security-policy
+;;    "object-src 'none';base-uri 'self';script-src 'nonce-xM7BqmSpeu5Zd6usKOP4JA' 'strict-dynamic' 'report-sample' 'unsafe-eval' 'unsafe-inline' https: http:;report-uri https://csp.withgoogle.com/csp/gws/cdt1",
+;;    :alt-svc
+;;    "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+;;    :content-type "application/json; charset=UTF-8",
+;;    :cross-origin-opener-policy "same-origin-allow-popups; report-to=\"gws\"",
+;;    :content-encoding "br"},
+;;   :mime "application/json",
+;;   :remote-ip "142.251.41.36"},
+;;  :done? true};; => nil
+----
+
+A typical pattern of `get-ajax` usage is the following.
+You'd like to check if a certain request has been fired to the server.
+So you press a button, wait for a while, and then read the requests made by your browser.
+
+Having a list of requests, you search for the one you need (e.g. by its URL) and then check its state.
+The `:state` field has got the same semantics of the `XMLHttpRequest.readyState`.
+It's an integer from 1 to 4 with the same behavior.
+
+To check if a request has been finished, done or failed, use these predicates:
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+;; fill the logs
+(e/go driver "https://google.com")
+(e/wait 2) ;; give ajax requests a chance to finish
+
+(def reqs (dev/get-ajax driver))
+;; you'd search for what you are interested in here
+(def req (last reqs))
+
+(dev/request-done? req)
+;; => true
+
+(dev/request-failed? req)
+;; => nil
+
+(dev/request-success? req)
+;; => true
+----
+
+Note that `request-done?` doesn't mean the request has succeeded.
+It only means its pipeline has reached a final step.
+
+TIP: when you read dev logs, you consume them from an internal buffer which gets flushed.
+The second call to `get-requests` or `get-ajax` will return an empty list.
+
+Perhaps you want to collect these logs.
+A function `dev/get-performance-logs` return a list of logs so you accumulate them in an atom or whatever:
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+;; setup a collector
+(def logs (atom []))
+
+;; make requests
+(e/refresh driver)
+
+;; collect as needed
+(do (swap! logs concat (dev/get-performance-logs driver))
+    true)
+
+(count @logs)
+;; 136
+----
+
+The `+logs->requests+` and `+logs->ajax+` functions convert already fetched logs into requests.
+Unlike `get-requests` and `get-ajax`, they are pure functions and won't flush anything.
+
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+;; convert our fetched requests from our collector atom
+(dev/logs->requests @logs)
+(last (dev/logs->requests @logs))
+;;    {:state 4,
+;;     :id "14535.162",
+;;     :type :ping,
+;;     :xhr? false,
+;;     :url
+;;     "https://www.google.com/gen_204?atyp=i&r=1&ei=Zd2aYsrzLozStQbzgbqIBQ&ct=slh&v=t1&m=HV&pv=0.48715273690818806&me=1:1654316389931,V,0,0,1200,1053:0,B,1053:0,N,1,Zd2aYsrzLozStQbzgbqIBQ:0,R,1,1,0,0,1200,1053:93,x:42832,e,U&zx=1654316432856",
+;;     :with-data? true,
+;;     :request
+;;     {:method :post,
+;;      :headers
+;;      {:Referer "https://www.google.com/",
+;;       :sec-ch-ua-full-version-list
+;;       "\" Not A;Brand\";v=\"99.0.0.0\", \"Chromium\";v=\"102.0.5005.61\", \"Google Chrome\";v=\"102.0.5005.61\"",
+;;       :sec-ch-viewport-width "1200",
+;;       :sec-ch-ua-platform-version "\"10.15.7\"",
+;;       :sec-ch-ua
+;;       "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"102\", \"Google Chrome\";v=\"102\"",
+;;       :sec-ch-ua-platform "\"macOS\"",
+;;       :sec-ch-ua-full-version "\"102.0.5005.61\"",
+;;       :sec-ch-ua-wow64 "?0",
+;;       :sec-ch-ua-model "",
+;;       :sec-ch-ua-bitness "\"64\"",
+;;       :sec-ch-ua-mobile "?0",
+;;       :sec-ch-dpr "1",
+;;       :sec-ch-ua-arch "\"x86\"",
+;;       :User-Agent
+;;       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
+;;     :response
+;;     {:status nil,
+;;      :headers
+;;      {:alt-svc
+;;       "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+;;       :bfcache-opt-in "unload",
+;;       :content-length "0",
+;;       :content-type "text/html; charset=UTF-8",
+;;       :date "Sat, 04 Jun 2022 04:20:32 GMT",
+;;       :server "gws",
+;;       :x-frame-options "SAMEORIGIN",
+;;       :x-xss-protection "0"},
+;;      :mime "text/html",
+;;      :remote-ip "142.251.41.36"},
+;;     :done? true}
+----
+
+When working with logs and requests, pay attention it their count and size.
+The maps have plenty of keys and the amount of items in collections came be very large.
+Printing a slew of events might freeze your editor.
+Consider using `clojure.pprint/pprint` as it relies on max level and length limits.
+
+// hidden cleanup of our devtools driver
+ifdef::env-test-doc-blocks[]
+//{:test-doc-blocks/test-ns user-guide-devtools-test}
+[source,clojure]
+----
+(e/quit driver)
+----
+endif::[]
+
+=== Postmortem: Auto-save Artifacts in Case of Exception [[postmortem]]
+
+Sometimes, it can be difficult to diagnose what went wrong during a failed UI test run.
+Use the `with-postmortem` to save useful data to disk before the exception was triggered:
+
+* a screenshot of the visible browser page
+* HTML code of the current browser page
+* JS console logs, <<console-logs,if available for your browser>>
+
 Example:
 
 [source,clojure]
 ----
-(screenshot-element driver {:tag :div :class :smart-widget} "smart_widget.png")
+(try
+  (e/with-postmortem driver {:dir "target/etaoin-play/postmortem"}
+    (e/click driver :non-existing-element))
+  (catch Exception _e
+    "yup, we threw!"))
+;; => "yup, we threw!"
 ----
 
-=== Screening after each form
+An exception will occur. Under `target/etaoin-postmortem` you will find three postmortem files named like so: `<browser>-<host>-<port>-<datetime>.<ext>`, for example:
 
-With macro `with-screenshots`, you can make a screenshot after each form
+[source,shell]
+----
+$ tree target
+target
+└── etaoin-postmortem
+    ├── chrome-127.0.0.1-49766-2022-06-04-12-26-31.html
+    ├── chrome-127.0.0.1-49766-2022-06-04-12-26-31.json
+    └── chrome-127.0.0.1-49766-2022-06-04-12-26-31.png
+----
+
+The available `with-postmortem` options are:
 
 [source,clojure]
 ----
-(with-screenshots driver "../screenshots"
-  (fill driver :simple-input "1")
-  (fill driver :simple-input "2")
-  (fill driver :simple-input "3"))
+{;; directory to save artifacts
+ ;; will be created if it does not already exist, defaults to current working directory
+ :dir "/home/ivan/UI-tests"
+
+ ;; directory to save screenshots; defaults to :dir
+ :dir-img "/home/ivan/UI-tests/screenshots"
+
+ ;; the same but for HTML sources
+ :dir-src "/home/ivan/UI-tests/HTML"
+
+ ;; the same but for console logs
+ :dir-log "/home/ivan/UI-tests/console"
+
+ ;; a string template to format a timestamp; See SimpleDateFormat Java class
+ :date-format "yyyy-MM-dd-HH-mm-ss"}
 ----
 
-what is equivalent to a record:
+== Additional Driver Parameters [[parameters]]
 
+When creating a driver instance, a map of additional parameters can be passed to tweak the WebDriver and web browser behaviour.
+
+Here, for example, we set an explicit path to the chrome WebDriver binary:
+
+//:test-doc-blocks/skip
 [source,clojure]
 ----
-(fill driver :simple-input "1")
-(screenshot driver "../screenshots/chrome-...123.png")
-(fill driver :simple-input "2")
-(screenshot driver "../screenshots/chrome-...124.png")
-(fill driver :simple-input "3")
-(screenshot driver "../screenshots/chrome-...125.png")
+(def driver (e/chrome {:path-driver "/Users/ivan/downloads/chromedriver"}))
 ----
 
-== Using headless drivers
+[cols="70,30"]
+|===
+| Option | Defaults
 
-Recently, Google Chrome and later Firefox started support a feature named headless mode.
-When being headless, none of UI windows occur on the screen, only the stdout output goes into console.
-This feature allows you to run integration tests on servers that do not have graphical output device.
+a|`:host` for *WebDriver* process. When:
 
-Ensure your browser supports headless mode by checking if it accepts `--headles` command line argument when running it from the terminal.
-Phantom.js driver is headless by its nature (it has never been developed for rendering UI).
+* omitted, creates a new local WebDriver process.
+* specified, attempts to connect to an existing running WebDriver process.
+See <<connecting-existing>>.
+
+Example: `:host "192.68.1.12"`
+| <not set>
+
+|`:port` for *WebDriver* process.
+If `:port` is found to  already in use when creating a new local WebDriver process (see `:host`), a random port will be automatically selected. +
+See also <<connecting-existing>>.
+
+Example: `:port 9997`
+a| Varies by vendor:
+
+* chrome `9515`
+* firefox `4444`
+* safari `4445`
+* edge `17556`
+* phantom `8910`
+
+| `:path-driver` to *WebDriver* binary. +
+Typically used if your WebDriver is not on the PATH.
+
+Example:
+`:path-driver "/Users/ivan/Downloads/geckodriver"`
+a| As you would expect, varies by vendor:
+
+* chrome `"chromedriver"`
+* firefox `"geckodriver"`
+* safari `"safaridriver"`
+* edge `"msedgedriver"`
+* phantom `"phantomjs"`
+
+| `:args-driver` specifies extra command line arguments to *WebDriver*.
+
+Example: `:args-driver ["-b" "/path/to/firefox/binary"]`
+| <not set>
+
+| `:path-browser` to *web browser* binary. +
+Typically used if your browser is not on the PATH.
+
+Example: `:path-browser "/Users/ivan/Downloads/firefox/firefox"`
+| By default, the WebDriver process automatically finds the web browser.
+
+| `:args` specifies extra command line arguments to *web browser*, see your web browser docs for what is available.
+
+Example: `:args ["--incognito" "--app" "http://example.com"]`
+| <not set>
+
+a| `:log-level` *web browser* minimal console log level.
+Only message with this level and above will be collected.
+From least to most verbose:
+
+* `nil`, `:off` or `:none` for no messages
+* `:err`, `:error`, `:severe`, `:crit` or `:critical`
+* `:warn` or `:warning`
+* `:debug`
+* `:all` for all messages.
+
+See <<console-logs>>
+
+Example: `:log-level :err`
+
+| `:all`
+
+a| `driver-log-level` *WebDriver* minimal log level.
+values vary by browser driver vendor:
+
+* chrome `"OFF"` `"SEVERE"` `"WARNING"` `"INFO"` or `"DEBUG"`
+* firefox `"fatal"` `"error"` `"warn"` `"info"` `"config"` `"debug"` or `"trace"`
+* phantomjs `"ERROR"` `"WARN"` `"INFO"` `"DEBUG"`
+
+Example: `:driver-log-level "INFO"`
+
+a| * phantomjs `"INFO"`
+
+a| `:log-stdout` and `:log-stderr` *WebDriver* stdout and stderr log files
+
+Example:
+[source,clojure]
+----
+  :log-stdout "target/chromedriver-out.log"
+  :log-stderr "target/chrmoedriver-err.log"
+----
+| `/dev/null`, on Windows `NUL`
+
+| `:profile` path to custom *web browser* profile, see <<browser-profile>>
+
+Example: +
+`:profile "/Users/ivan/Library/Application Support/Firefox/Profiles/iy4iitbg.Test"`
+
+| <not set>
+
+| `:env` map of environment variables for *WebDriver* process.
+
+Example: `:env {:MOZ_CRASHREPORTER_URL "http://test.com"}`
+| <not set>
+
+| `:size` initial *web browser* window width and height in pixels
+
+Example: `size: [640 480]`
+| [1024 680]
+
+| `:url` default URL to open in *web browser*.+
+Only works in Firefox at this time.
+
+Example: `:url "https://clojure.org"`
+| <not set>
+
+| `:user-agent` overrides the *web browser* `User-Agent`.
+Useful for headless mode.
+See <<user-agent>>.
+
+Example: `:user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"`
+| Default is governed by WebDriver vendor.
+
+| `:download-dir` directory for *web browser* downloads files.
+See <<download-dir>>
+
+Example: `:download-dir "target/chrome-downloads"`
+| Default is governed by browser vendor.
+
+| `:headless` run the *web browser* without a UI.
+See <<headless>>.
+
+Example `:headless true`
+| Normally `false`, but automatically set for driver creation functions like `chrome-headless`, `with-chrome-headless` etc.
+
+| `:prefs` map of *web browser* specific preferences.
+
+Example: see one usage in <<download-dir>>.
+| <not set>
+
+| `:proxy` to set *web browser* proxy.
+
+Example: see <<http-proxy>>.
+| <not set>
+
+| `:load-strategy` controls how long the *WebDriver* should wait before interacting with a page.
+See <<load-strategy>>.
+
+Example: `:load-strategy :none`
+| `:normal`
+
+| `:capabilities` *WebDriver*-specific options.
+Read vendor docs for WebDriver before setting anything here.
+You'll find an example ussage under <<http-proxy>>.
+| <none>
+
+|===
+
+=== Using Headless Drivers [[headless]]
+
+Google Chrome, Firefox and Microsoft Edge can be run in headless mode.
+When headless, none of UI windows appear on the screen.
+Running without a UI is helpful when:
+
+* running integration tests on servers that do not have graphical output device
+* running local tests without having them take over your local UI
+
+Ensure your browser supports headless mode by checking if it accepts `--headless` command line argument when running it from the terminal.
+The Phantom.js driver is headless by its nature (it was never been developed for rendering UI).
 
 When starting a driver, pass `:headless` boolean flag to switch into headless mode.
-Note, only latest version of Chrome and Firefox are supported.
-For other drivers, the flag will be ignored.
+This flag is ignored for Safari which, as of June 2022, still does not support headless mode.
 
+//{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
 ----
-(def driver (chrome {:headless true})) ;; runs headless Chrome
+(require '[etaoin.api :as e])
+
+(def driver (e/chrome {:headless true})) ;; runs headless Chrome
+;; do some stuff
+(e/quit driver)
 ----
 
 or
 
+//{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
 ----
-(def driver (firefox {:headless true})) ;; runs headless Firefox
+(def driver (e/firefox {:headless true})) ;; runs headless Firefox
+;; you can also check if a driver is in headless mode:
+(e/headless? driver)
+;; => true
+(e/quit driver)
 ----
 
-To check of any driver has been run in headless mode, use `headless?` predicate:
+NOTE: PhantomJS will always be in headless mode.
 
+There are several shortcuts to run Chrome or Firefox in headless mode:
+
+//{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
 ----
-(headless? driver) ;; true
-----
-
-Note, it will always return true for Phantom.js instances.
-
-There are several shortcuts to run Chrome or Firefox in headless mode by default:
-
-[source,clojure]
-----
-(def driver (chrome-headless))
+(def driver (e/chrome-headless))
+;; do some stuff
+(e/quit driver)
 
 ;; or
 
-(def driver (firefox-headless {...})) ;; with extra settings
+(def driver (e/firefox-headless {:log-level :all})) ;; with extra settings
+;; do some stuff
+(e/quit driver)
 
 ;; or
 
-(with-chrome-headless nil driver
-  (go driver "http://example.com"))
+(require '[etaoin.api2 :as e2])
 
-(with-firefox-headless {...} driver ;; extra settings
-  (go driver "http://example.com"))
+(e2/with-chrome-headless [driver]
+  (e/go driver "https://clojure.org"))
+
+(e2/with-firefox-headless [driver {:log-level :all}] ;; extra settings
+  (e/go driver "https://clojure.org"))
 ----
 
-There are also `when-headless` and `when-not-headless` macroses that allow to perform a bunch of commands only if a browser is in headless mode or not respectively:
+There are also `when-headless` and `when-not-headless` macros that allow to perform a block of commands only if a browser is in headless mode or not respectively:
+
+//{:test-doc-blocks/test-ns user-guide-headless-test}
+[source,clojure]
+----
+(e2/with-chrome [driver]
+  (e/when-not-headless driver
+    ;;... some actions that might be not available in headless mode
+    )
+  ;;... common actions for both versions
+  )
+----
+
+=== File Download Directory [[download-dir]]
+
+To specify a directory where the browser should download files, use the `:download-dir` option:
+
+//:test-doc-blocks/skip
+[source,clojure]
+----
+(def driver (e/chrome {:download-dir "target/etaoin-play/chrome-downloads"}))
+;; do some downloading
+(e/driver quit)
+----
+
+Now, when you click on a download link, the file will be saved to that folder.
+Currently, only Chrome and Firefox are supported.
+
+Firefox requires specifying MIME-types of the files that should be downloaded without showing a system dialog.
+By default, when the `:download-dir` parameter is passed, the library adds the most common MIME-types: archives, media files, office documents, etc.
+If you need to add your own one, override that Firefox preference manually via the `:prefs` option:
+
+//:test-doc-blocks/skip
+[source,clojure]
+----
+(def driver (e/firefox {:download-dir "target/etaoin-play/firefox-downloads"
+                        :prefs {:browser.helperApps.neverAsk.saveToDisk
+                                "some-mime/type-1;other-mime/type-2"}}))
+;; do some downloading
+(e/driver quit)
+----
+
+To check whether a file was downloaded during UI tests, see <<test-file-downloads>>.
+
+=== Managing User-Agent [[user-agent]]
+
+Set a custom `User-Agent` header with the `:user-agent` option when creating a driver, for example:
 
 [source,clojure]
 ----
-(with-chrome nil driver
-  ...
-  (when-not-headless driver
-    ... some actions that might be not available in headless mode)
-  ... common actions for both versions)
+(e2/with-firefox [driver {:user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"}]
+  (e/get-user-agent driver))
+;; => "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
 ----
 
-== Connection to remote webdriver
+Setting this header is important when using <<headless,headless browsers>> as many web sites implement some sort of blocking when the User-Agent includes the "headless" string.
+This can lead to 403 response or some weird behavior of the site.
 
-To connect to a driver already running on a local or remote host, you must specify the `:host` parameter which might be either a hostname (localhost, some.remote.host.net) or an IP address (127.0.0.1, 183.102.156.31) and the `:port`.
-If the port is not specified, the default port is set.
-
-Example:
-
-[source,clojure]
-----
-;; Chrome
-(def driver (chrome {:host "127.0.0.1" :port 9515})) ;; for connection to driver on localhost on port 9515
-
-;; Firefox
-(def driver (firefox {:host "192.168.1.11"})) ;; the default port for firefox is 4444
-----
-
-== Webdriver in Docker
-
-To work with the driver in Docker, you can take ready-made images:
-
-Example for https://hub.docker.com/r/robcherry/docker-chromedriver/[Chrome]:
-
-----
-docker run --name chromedriver -p 9515:4444 -d -e CHROMEDRIVER_WHITELISTED_IPS='' robcherry/docker-chromedriver:latest
-----
-
-for https://hub.docker.com/r/instrumentisto/geckodriver[Firefox]:
-
-----
-docker run --name geckodriver -p 4444:4444 -d instrumentisto/geckodriver
-----
-
-To connect to the driver you just need to specify the `:host` parameter as `localhost` or `127.0.0.1` and the `:port` on which it is running.
-If the port is not specified, the default port is set.
-
-[source,clojure]
-----
-(def driver (chrome-headless {:host "localhost" :port 9515 :args ["--no-sandbox"]}))
-(def driver (firefox-headless {:host "localhost"})) ;; will try to connect to port 4444
-----
-
-== HTTP Proxy
+=== HTTP Proxy [[http-proxy]]
 
 To set proxy settings use environment variables `HTTP_PROXY`/`HTTPS_PROXY` or pass a map of the following type:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 {:proxy {:http "some.proxy.com:8080"
@@ -933,479 +2194,58 @@ To set proxy settings use environment variables `HTTP_PROXY`/`HTTPS_PROXY` or pa
          :pac-url "localhost:8888"}}
 
 ;; example
-(chrome {:proxy {:http "some.proxy.com:8080"
-                 :ssl "some.proxy.com:8080"}})
+(e/chrome {:proxy {:http "some.proxy.com:8080"
+                   :ssl "some.proxy.com:8080"}})
 ----
 
-NOTE: A :pac-url for a https://en.wikipedia.org/wiki/Proxy_auto-config#The_PAC_File[proxy autoconfiguration file].
-Used with Safari as the other proxy options do not work in that browser.
+NOTE: A `:pac-url` is for a https://en.wikipedia.org/wiki/Proxy_auto-config#The_PAC_File[proxy autoconfiguration file].
+Used with Safari as other proxy options do not work in Safari.
 
-To fine tune the proxy you can use the original https://www.w3.org/TR/webdriver/#proxy[object] and pass it to capabilities:
+To fine tune the proxy you use the original https://www.w3.org/TR/webdriver/#proxy[object] and pass it to capabilities:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
-{:capabilities {:proxy {:proxyType "manual"
-                        :proxyAutoconfigUrl "some.proxy.com:8080"
-                        :ftpProxy "some.proxy.com:8080"
-                        :httpProxy "some.proxy.com:8080"
-                        :noProxy ["http://this.url" "http://that.url"]
-                        :sslProxy "some.proxy.com:8080"
-                        :socksProxy "some.proxy.com:1080"
-                        :socksVersion 5}}}
-
-(chrome {:capabilities {:proxy {...}}})
+(e/chrome {:capabilities
+           {:proxy
+            {:proxyType "manual"
+             :proxyAutoconfigUrl "some.proxy.com:8080"
+             :ftpProxy "some.proxy.com:8080"
+             :httpProxy "some.proxy.com:8080"
+             :noProxy ["http://this.url" "http://that.url"]
+             :sslProxy "some.proxy.com:8080"
+             :socksProxy "some.proxy.com:1080"
+             :socksVersion 5}}})
 ----
+=== Connecting to an Existing Running WebDriver [[connecting-existing]]
 
-== Devtools: tracking HTTP requests, XHR (Ajax)
+To connect to an existing WebDriver, specify the `:host` parameter.
 
-With recent updates, the library brings a great feature.
-Now you can trace events which come from the DevTools panel.
-It means, everything you see in the developer console now is available through API.
-That works only with Google Chrome now.
+TIP: When the `:host` parameter is not specified Etaoin will create a new WebDriver process.
 
-To start a driver with special development settings specified, just pass an empty map to the `:dev` field when running a driver:
-
-[source,clojure]
-----
-(def c (chrome {:dev {}}))
-----
-
-The value must not be `nil`.
-When it's an empty map, a special function takes defaults.
-Here is a full version of dev settings with all the possible values specified.
-
-[source,clojure]
-----
-(def c (chrome {:dev
-                {:perf
-                 {:level :all
-                  :network? true
-                  :page? true
-                  :interval 1000
-                  :categories [:devtools
-                               :devtools.network
-                               :devtools.timeline]}}}))
-----
-
-Under the hood, it fills a special `perfLoggingPrefs` dictionary inside the `chromeOptions` object.
-
-Now that your browser accumulates these events, you can read them using a special `dev` namespace.
-
-[source,clojure]
-----
-(go c "http://google.com")
-;; wait until the page gets loaded
-
-;; load the namespace
-(require '[etaoin.dev :as dev])
-----
-
-Let's have a list of ALL the HTTP requests happened during the page was loading.
-
-[source,clojure]
-----
-(def reqs (dev/get-requests c))
-
-;; reqs is a vector of maps
-(count reqs)
-;; 19
-
-;; what were their types?
-(set (map :type reqs))
-;; #{:script :other :document :image :xhr}
-;; we've got Js requests, images, AJAX and other stuff
-----
-
-[source,clojure]
-----
-;; check the last one request, it's an image named tia.png
-(-> reqs last clojure.pprint/pprint)
-
-{:state 4,
- :id "1000052292.8",
- :type :image,
- :xhr? false,
- :url "https://www.gstatic.com/inputtools/images/tia.png",
- :with-data? nil,
- :request
- {:method :get,
-  :headers
-  {:Referer "https://www.google.com/",
-   :User-Agent
-   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36"}},
- :response
- {:status 200,
-  :headers {}, ;; truncated
-  :mime "image/png",
-  :remote-ip "173.194.73.94"},
- :done? true}
-----
-
-Since we're mostly interested in AJAX requests, there is a function `get-ajax` that does the same but filters XHR requests:
-
-[source,clojure]
-----
-(-> c dev/get-ajax last clojure.pprint/pprint)
-
-{:state 4,
- :id "1000051989.41",
- :type :xhr,
- :xhr? true,
- :url
- "https://www.google.com/complete/search?q=clojure%20spec&cp=12&client=psy-ab&xssi=t&gs_ri=gws-wiz&hl=ru&authuser=0&psi=4iUbXdapJsbmrgTVt7H4BA.1562060259137&ei=4iUbXdapJsbmrgTVt7H4BA",
- :with-data? nil,
- :request
- {:method :get,
-  :headers
-  {:Referer "https://www.google.com/",
-   :User-Agent
-   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36"}},
- :response
- {:status 200,
-  :headers {}, ;; truncated
-  :mime "application/json",
-  :remote-ip "74.125.131.99"},
- :done? true}
-----
-
-A typical pattern of `get-ajax` usage is the following.
-You'd like to check if a certain request has been fired to the server.
-So you press a button, wait for a while and then read the requests made by your browser.
-
-Having a list of requests, you search for the one you need (e.g.
-by its URL) and then check its state.
-The `:state` field's got the same semantics like the `XMLHttpRequest.readyState` has.
-It's an integer from 1 to 4 with the same behavior.
-
-To check if a request has been finished, done or failed, use these predicates:
-
-[source,clojure]
-----
-(def req (last reqs))
-
-(dev/request-done? req)
-;; true
-
-(dev/request-failed? req)
-;; false
-
-(dev/request-success? req)
-;; true
-----
-
-Note that `request-done?` doesn't mean the request has succeeded.
-It only means its pipeline has reached a final step.
-
-WARNING: when you read dev logs, you consume them from an internal buffer which gets flushed.
-The second call to `get-requests` or `get-ajax` will return an empty list.
-
-Perhaps you want to collect these logs by your own.
-A function `dev/get-performance-logs` return a list of logs so you accumulate them in an atom or whatever:
-
-[source,clojure]
-----
-(def logs (atom []))
-
-;; repeat that form from time to time
-(do (swap! logs concat (dev/get-performance-logs c))
-    true)
-
-(count @logs)
-;; 76
-----
-
-There are `+logs->requests+` and `+logs->ajax+` functions that convert logs into requests.
-Unlike `get-requests` and `get-ajax`, they are pure functions and won't flush anything.
-
-[source,clojure]
-----
-(dev/logs->requests @logs)
-----
-
-When working with logs and requests, pay attention it their count and size.
-The maps have got plenty of keys and the amount of items in collections might be huge.
-Printing a whole bunch of events might freeze your editor.
-Consider using `clojure.pprint/pprint` function as it relies on max level and length limits.
-
-== Postmortem: auto-save artifacts in case of exception
-
-Sometimes, it might be difficult to discover what went wrong during the last UI tests session.
-A special macro `with-postmortem` saves some useful data on disk before the exception was triggered.
-Those data are a screenshot, HTML code and JS console logs.
-Note: not all browsers support getting JS logs.
+The `:host` can be a hostname (localhost, some.remote.host.net) or an IP address (127.0.0.1, 183.102.156.31).
+If the port is not specified, the <<parameters,default>> `:port` is assumed.
 
 Example:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
-(def driver (chrome))
-(with-postmortem driver {:dir "/Users/ivan/artifacts"}
-  (click driver :non-existing-element))
+;; Connect to an existing chromedriver process on localhost on port 9515
+(def driver (e/chrome {:host "127.0.0.1" :port 9515})) ;; for connection to driver on localhost on port 9515
+
+;; Connect to an existing geckodriver process on remote most on default port
+(def driver (e/firefox {:host "192.168.1.11"})) ;; the default port for firefox is 4444
 ----
 
-An exception will rise, but in `/Users/ivan/artifacts` there will be three files named by a template `<browser>-<host>-<port>-<datetime>.<ext>`:
+=== Setting the Browser Profile [[browser-profile]]
 
-* `firefox-127.0.0.1-4444-2017-03-26-02-45-07.png`: an actual screenshot of the browser's page;
-* `firefox-127.0.0.1-4444-2017-03-26-02-45-07.html`: the current browser's HTML content;
-* `firefox-127.0.0.1-4444-2017-03-26-02-45-07.json`: a JSON file with console logs;
-those are a vector of objects.
-
-The handler takes a map of options with the following keys.
-All of them might be absent.
-
-[source,clojure]
-----
-{;; default directory where to store artifacts
- ;; might not exist, will be created otherwise. pwd is used when not passed
- :dir "/home/ivan/UI-tests"
-
- ;; a directory where to store screenshots; :dir is used when not passed
- :dir-img "/home/ivan/UI-tests/screenshots"
-
- ;; the same but for HTML sources
- :dir-src "/home/ivan/UI-tests/HTML"
-
- ;; the same but for console logs
- :dir-log "/home/ivan/UI-tests/console"
-
- ;; a string template to format a date; See SimpleDateFormat Java class
- :date-format "yyyy-MM-dd-HH-mm-ss"}
-----
-
-== Reading browser's logs
-
-Function `(get-logs driver)` returns the browser's logs as a vector of maps.
-Each map has the following structure:
-
-[source,clojure]
-----
-{:level :warning,
- :message "1,2,3,4  anonymous (:1)",
- :timestamp 1511449388366,
- :source nil,
- :datetime #inst "2017-11-23T15:03:08.366-00:00"}
-----
-
-Currently, logs are available in Chrome and Phantom.js only.
-Please note, the message text and the source type highly depend on the browser.
-Chrome wipes the logs once they have been read.
-Phantom.js keeps them but only until you change the page.
-
-== Additional parameters
-
-When running a driver instance, a map of additional parameters might be passed to tweak the browser's behaviour:
-
-[source,clojure]
-----
-(def driver (chrome {:path "/path/to/driver/binary"}))
-----
-
-Below, here is a map of parameters the library support.
-All of them might be skipped or have nil values.
-Some of them, if not passed, are taken from the `defaults` map.
-
-[source,clojure]
-----
-{;; Host and port for webdriver's process. Both are taken from defaults
- ;; when are not passed. If you pass a port that has been already taken,
- ;; the library will try to take a random one instead.
- :host "127.0.0.1"
- :port 9999
-
- ;; Path to webdriver's binary file. Taken from defaults when not passed.
- :path-driver "/Users/ivan/Downloads/geckodriver"
-
- ;; Path to the driver's binary file. When not passed, the driver discovers it
- ;; by its own.
- :path-browser "/Users/ivan/Downloads/firefox/firefox"
-
- ;; Extra command line arguments sent to the browser's process. See your browser's
- ;; supported flags.
- :args ["--incognito" "--app" "http://example.com"]
-
- ;; Extra command line arguments sent to the webdriver's process.
- :args-driver ["-b" "/path/to/firefox/binary"]
-
- ;; Sets browser's minimal logging level. Only messages with level above
- ;; that one will be collected. Useful for fetching Javascript logs. Possible
- ;; values are: nil (aliases :off, :none), :debug, :info, :warn (alias :warning),
- ;; :err (aliases :error, :severe, :crit, :critical), :all. When not passed,
- ;; :all is set.
- :log-level :err ;; to show only errors but not debug
-
- ;; Sets driver's log level.
- ;; The value is a string. Possible values are:
- ;; chrome: [ALL, DEBUG, INFO, WARNING, SEVERE, OFF]
- ;; phantomjs: [ERROR, WARN, INFO, DEBUG] (default INFO)
- ;; firefox [fatal, error, warn, info, config, debug, trace]
- :driver-log-level
-
- ;; Paths to the driver's log files as strings.
- ;; When not set, the output goes to /dev/null (or NUL on Windows)
- :log-stdout
- :log-stderr
-
- ;; Path to a custorm browser profile. See the section below.
- :profile "/Users/ivan/Library/Application Support/Firefox/Profiles/iy4iitbg.Test"
-
- ;; Env variables sent to the driver's process.
- :env {:MOZ_CRASHREPORTER_URL "http://test.com"}
-
- ;; Initial window size.
- :size [1024 680]
-
- ;; Default URL to open. Works only in FF for now.
- :url "http://example.com"
-
- ;; Override the default User-Agent. Useful for headless mode.
- :user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
-
- ;; Where to download files.
- :download-dir "/Users/ivan/Desktop"
-
- ;; Driver-specific options. Make sure you have read the docs before setting them.
- :capabilities {:chromeOptions {:args ["--headless"]}}}
-----
-
-== Eager page load
-
-When you navigate to a certain page, the driver waits until the whole page has been completely loaded.
-What's fine in most of the cases yet doesn't reflect the way human beings interact with the Internet.
-
-Change this default behavior with the `:load-strategy` option.
-There are three possible values for that: `:none`, `:eager` and `:normal` which is the default when not passed.
-
-When you pass `:none`, the driver responds immediately so you are welcome to execute next instructions.
-For example:
-
-[source,clojure]
-----
-(def c (chrome))
-(go c "http://some.slow.site.com")
-;; you'll hang on this line until the page loads
-(do-something)
-----
-
-Now when passing the load strategy option:
-
-[source,clojure]
-----
-(def c (chrome {:load-strategy :none}))
-(go c "http://some.slow.site.com")
-;; no pause, acts immediately
-(do-something)
-----
-
-For the `:eager` option, it works only with Firefox at the moment of adding the feature to the library.
-
-== Keyboard chords
-
-There is an option to input a series of keys simultaneously.
-That is useful to imitate holding a system key like Control, Shift or whatever when typing.
-
-The namespace `etaoin.keys` carries a bunch of key constants as well as a set of functions related to input.
-
-[source,clojure]
-----
-(require '[etaoin.keys :as keys])
-----
-
-A quick example of entering ordinary characters holding Shift:
-
-[source,clojure]
-----
-(def c (chrome))
-(go c "http://google.com")
-
-(fill-active c (keys/with-shift "caps is great"))
-----
-
-The main input gets populated with "CAPS IS GREAT".
-Now you'd like to delete the last word.
-In Chrome, this is done by pressing backspace holding Alt.
-Let's do that:
-
-[source,clojure]
-----
-(fill-active c (keys/with-alt keys/backspace))
-----
-
-Now you've got only "CAPS IS " in the input.
-
-Consider a more complex example which repeats real users' behaviour.
-You'd like to delete everything from the input.
-First, you move the caret at the very beginning.
-Then move it to the end holding shift so everything gets selected.
-Finally, you press delete to clear the selected text.
-
-The combo is:
-
-[source,clojure]
-----
-(fill-active c keys/home (keys/with-shift keys/end) keys/delete)
-----
-
-There are also `with-ctrl` and `with-command` functions that act the same.
-
-Pay attention, these functions do not apply to the global browser's shortcuts.
-For example, neither "Command + R" nor "Command + T" reload the page or open a new tab.
-
-All the `keys/with-*` functions are just wrappers upon the `keys/chord` function that might be used for complex cases.
-
-== File download directory
-
-To specify your own directory where to download files, pass `:download-dir` parameter into an option map when running a driver:
-
-[source,clojure]
-----
-(def driver (chrome {:download-dir "/Users/ivan/Desktop"}))
-----
-
-Now, once you click on a link, a file should be put into that folder.
-Currently, only Chrome and Firefox are supported.
-
-Firefox requires to specify MIME-types of those files that should be downloaded without showing a system dialog.
-By default, when the `:download-dir` parameter is passed, the library adds the most common MIME-types: archives, media files, office documents, etc.
-If you need to add your own one, override that preference manually:
-
-[source,clojure]
-----
-(def driver (firefox {:download-dir "/Users/ivan/Desktop"
-                      :prefs {:browser.helperApps.neverAsk.saveToDisk
-                              "some-mime/type-1;other-mime/type-2"}}))
-----
-
-To check whether a file was downloaded during UI tests, see the testing section below.
-
-== Managing User-Agent
-
-Set a custom User-Agent header with the `:user-agent` option when creating a driver, for example:
-
-[source,clojure]
-----
-(def f (firefox {:user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"}))
-----
-
-To get the current value of the header in runtime, use the function:
-
-[source,clojure]
-----
-(get-user-agent f)
-;; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
-----
-
-Setting that header is quite important for headless browsers as most of the sites check if the User-Agent includes the "headless" string.
-This could lead to 403 response or some weird behavior of the site.
-
-== Setting browser profile
-
-When running Chrome or Firefox, you may specify a special profile made for test purposes.
+When running Chrome or Firefox, you may specify a special web browser profile made for test purposes.
 A profile is a folder that keeps browser settings, history, bookmarks and other user-specific data.
 
-Imagine you'd like to run your integration tests against a user that turned off Javascript execution or image rendering.
-To prepare a special profile for that task would be a good choice.
+Imagine, for example, that you'd like to run your integration tests against a user that turned off Javascript execution or image rendering.
 
-=== Create and find a profile in Chrome
+==== Create and Find a Profile in Chrome
 
 . In the right top corner of the main window, click on a user button.
 . In the dropdown, select "Manage People".
@@ -1415,7 +2255,7 @@ Now, setup the new profile as you want.
 . Open `chrome://version/` page.
 Copy the file path that is beneath the `Profile Path` caption.
 
-=== Create and find a profile in Firefox
+==== Create and Find a Profile in Firefox
 
 . Run Firefox with `-P`, `-p` or `-ProfileManager` key as the https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-firefox-profiles[official page] describes.
 . Create a new profile and run the browser.
@@ -1425,309 +2265,47 @@ Near the `Profile Folder` caption, press the `Show in Finder` button.
 A new folder window should appear.
 Copy its path from there.
 
-=== Running a driver with a profile
+==== Running a Driver with a Profile
 
-Once you've got a profile path, launch a driver with a special `:profile` key as follows:
+Once you've got a profile path, launch a driver with the `:profile` key as follows:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 ;; Chrome
 (def chrome-profile
   "/Users/ivan/Library/Application Support/Google/Chrome/Profile 2/Default")
 
-(def chrm (chrome {:profile chrome-profile}))
+(def chrome-driver (e/chrome {:profile chrome-profile}))
 
 ;; Firefox
 (def ff-profile
   "/Users/ivan/Library/Application Support/Firefox/Profiles/iy4iitbg.Test")
 
-(def ff (firefox {:profile ff-profile}))
-----
-
-== Scrolling
-
-The library ships a set of functions to scroll the page.
-
-The most important one, `scroll-query` jumps the the first element found with the query term:
-
-[source,clojure]
-----
-(def driver (chrome))
-
-;; the form button placed somewhere below
-(scroll-query driver :button-submit)
-
-;; the main article
-(scroll-query driver {:tag :h1})
-----
-
-To jump to the absolute position, just use `scroll` as follows:
-
-[source,clojure]
-----
-(scroll driver 100 600)
-
-;; or pass a map with x and y keys
-(scroll driver {:x 100 :y 600})
-----
-
-To scroll relatively, use `scroll-by` with offset values:
-
-[source,clojure]
-----
-;; keeps the same horizontal position, goes up for 100 pixels
-(scroll-by driver 0 -100) ;; map parameter is also supported
-----
-
-There are two shortcuts to jump top or bottom of the page:
-
-[source,clojure]
-----
-(scroll-bottom driver) ;; you'll see the footer...
-(scroll-top driver)    ;; ...and the header again
-----
-
-The following functions scroll the page in all directions:
-
-[source,clojure]
-----
-(scroll-down driver 200)  ;; scrolls down by 200 pixels
-(scroll-down driver)      ;; scrolls down by the default (100) number of pixels
-
-(scroll-up driver 200)    ;; the same, but scrolls up...
-(scroll-up driver)
-
-(scroll-left driver 200)  ;; ...left
-(scroll-left driver)
-
-(scroll-right driver 200) ;; ... and right
-(scroll-right driver)
-----
-
-One note, in all cases the scroll actions are served with Javascript.
-Ensure your browser has it enabled.
-
-== Working with frames and iframes
-
-While working with the page, you cannot interact with those items that are put into a frame or an iframe.
-The functions below switch the current context on specific frame:
-
-[source,clojure]
-----
-(switch-frame driver :frameId) ;; now you are inside an iframe with id="frameId"
-(click driver :someButton)     ;; click on a button inside that iframe
-(switch-frame-top driver)      ;; switches on the top of the page again
-----
-
-Frames could be nested one into another.
-The functions take that into account.
-Say you have an HTML layout like this:
-
-[source,html]
-----
-<iframe src="...">
-  <iframe src="...">
-    <button id="the-goal">
-  </iframe>
-</iframe>
-----
-
-So you can reach the button with the following code:
-
-[source,clojure]
-----
-(switch-frame-first driver)  ;; switches to the first top-level iframe
-(switch-frame-first driver)  ;; the same for an iframe inside the previous one
-(click driver :the-goal)
-(switch-frame-parent driver) ;; you are in the first iframe now
-(switch-frame-parent driver) ;; you are at the top
-----
-
-To reduce number of code lines, there is a special `with-frame` macro.
-It temporary switches frames while executing the body returning its last expression and switching to the previous frame afterwards.
-
-[source,clojure]
-----
-(with-frame driver {:id :first-frame}
-  (with-frame driver {:id :nested-frame}
-    (click driver {:id :nested-button})
-    42))
-----
-
-The code above returns `42` staying at the same frame that has been before before evaluating the macros.
-
-== Executing Javascript
-
-To evaluate a Javascript code in a browser, run:
-
-[source,clojure]
-----
-(js-execute driver "alert(1)")
-----
-
-You may pass any additional parameters into the call and cath them inside a script with the `arguments` array-like object:
-
-[source,clojure]
-----
-(js-execute driver "alert(arguments[2].foo)" 1 false {:foo "hello!"})
-----
-
-As the result, `hello!` string will appear inside the dialog.
-
-To return any data into Clojure, just add `return` into your script:
-
-[source,clojure]
-----
-(js-execute driver "return {foo: arguments[2].foo, bar: [1, 2, 3]}"
-                   1 false {:foo "hello!"})
-;; {:bar [1 2 3], :foo "hello!"}
-----
-
-=== Asynchronous scripts
-
-If your script performs AJAX requests or operates on `setTimeout` or any other async stuff, you cannot just `return` the result.
-Instead, a special callback should be called against the data you'd like to achieve.
-The webdriver passes this callback as the last argument for your script and might be reached with the `arguments` array-like object.
-
-Example:
-
-[source,clojure]
-----
-(js-async
-  driver
-  "var args = arguments; // preserve the global args
-  var callback = args[args.length-1];
-  setTimeout(function() {
-    callback(args[0].foo.bar.baz);
-  },
-  1000);"
-  {:foo {:bar {:baz 42}}})
-----
-
-returns `42` to the Clojure code.
-
-To evaluate an asynchronous script, you need either to setup a special timeout for that:
-
-[source,clojure]
-----
-(set-script-timeout driver 5) ;; in seconds
-----
-
-or wrap the code into a macros that does it temporary:
-
-[source,clojure]
-----
-(with-script-timeout driver 30
-  (js-async driver "some long script"))
-----
-
-== Wait functions
-
-The main difference between a program and a human being is that the first one operates very fast.
-It means so fast, that sometimes a browser cannot render new HTML in time.
-So after each action you'd better to put `wait-<something>` function that just polls a browser until the predicate evaluates into true.
-Or just `(wait <seconds>)` if you don't care about optimization.
-
-The `with-wait` macro might be helpful when you need to prepend each action with `(wait n)`.
-For example, the following form
-
-[source,clojure]
-----
-(with-chrome {} driver
-  (with-wait 3
-    (go driver "http://site.com")
-    (click driver {:id "search_button"})))
-----
-
-turns into something like this:
-
-[source,clojure]
-----
-(with-chrome {} driver
-  (wait 3)
-  (go driver "http://site.com")
-  (wait 3)
-  (click driver {:id "search_button"}))
-----
-
-and thus returns the result of the last form of the original body.
-
-There is another macro `(doto-wait n driver & body)` that acts like the standard `doto` but prepend each form with `(wait n)`.
-For example:
-
-[source,clojure]
-----
-(with-chrome {} driver
-  (doto-wait 1 driver
-    (go "http://site.com")
-    (click :this-link)
-    (click :that-button)
-    ...etc))
-----
-
-The final form would be something like this:
-
-[source,clojure]
-----
-(with-chrome {} driver
-  (doto driver
-    (wait 1)
-    (go "http://site.com")
-    (wait 1)
-    (click :this-link)
-    (wait 1)
-    (click :that-button)
-    ...etc))
-----
-
-In addition to `with-wait` and `do-wait` there are a number of waiting functions: `wait-visible`, `wait-has-alert`, `wait-predicate`, etc (see the full list in the link:{url-doc}/CURRENT/api/etaoin.api#wait[API docs].
-They accept default timeout/interval values that can be redefined using the `with-wait-timeout` and `with-wait-interval` macros, respectively.
-
-Example from etaoin test:
-
-[source,clojure]
-----
-(deftest test-wait-has-text
-  (testing "wait for text simple"
-    (with-wait-timeout 15 ;; time in seconds
-      (doto *driver*
-        (refresh)
-        (wait-visible {:id :document-end})
-        (click {:id :wait-button})
-        (wait-has-text :wait-span "-secret-"))
-      (is true "text found"))))
-----
-
-Wait text:
-
-* `wait-has-text` waits until an element has text anywhere inside it (including inner HTML).
-+
-[source,clojure]
-----
-(wait-has-text driver :wait-span "-secret-")
-----
-
-* `wait-has-text-everywhere` like `wait-has-text` but searches for text across the entire page
-+
-[source,clojure]
-----
-(wait-has-text-everywhere driver "-secret-")
+(def firefox-driver (e/firefox {:profile ff-profile}))
 ----
 
 == Writing Integration Tests For Your Application
 
-=== Basic fixture
+=== Basic Fixture
 
-To make your test not depend on each other, you need to wrap them into a fixture that will create a new instance of a driver and shut it down properly at the end if each test.
+It is desirable to have your tests be independent of one another.
+One way to achieve this is through the use of a test fixture.
+The fixture's job is to, for each test:
 
-Good solution might be to have a global variable (unbound by default) that will point to the target driver during the tests.
+1. create a new driver
+2. run the test with the driver
+3. shutdown the driver
 
+A dynamic `+*driver*+` var might be used to hold the driver.
+
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 (ns project.test.integration
   "A module for integration tests"
-  (:require [clojure.test :refer :all]
-            [etaoin.api :refer :all]))
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [etaoin.api :as e]))
 
 (def ^:dynamic *driver*)
 
@@ -1735,7 +2313,7 @@ Good solution might be to have a global variable (unbound by default) that will 
   "Executes a test running a driver. Bounds a driver
    with the global *driver* variable."
   [f]
-  (with-chrome {} driver
+  (e/with-chrome [driver]
     (binding [*driver* driver]
       (f))))
 
@@ -1748,37 +2326,39 @@ Good solution might be to have a global variable (unbound by default) that will 
 (deftest ^:integration
   test-some-case
   (doto *driver*
-    (go url-project)
-    (click :some-button)
-    (refresh)
+    (e/go url-project)
+    (e/click :some-button)
+    (e/refresh)
     ...
     ))
 ----
 
-If for some reason you want to use a single instance, you can use fixtures like this:
+If for some reason you want to reuse a single driver instance for all tests:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 (ns project.test.integration
   "A module for integration tests"
-  (:require [clojure.test :refer :all]
-            [etaoin.api :refer :all]))
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [etaoin.api :as e]
+            [etaoin.api :as e2]))
 
 (def ^:dynamic *driver*)
 
 (defn fixture-browser [f]
-  (with-chrome-headless {:args ["--no-sandbox"]} driver
-    (disconnect-driver driver)
+  (e2/with-chrome-headless [driver {:args ["--no-sandbox"]}]
+    (e/disconnect-driver driver)
     (binding [*driver* driver]
       (f))
-    (connect-driver driver)))
+    (e/connect-driver driver)))
 
 ;; creating a session every time that automatically erases resources
 (defn fixture-clear-browser [f]
-  (connect-driver *driver*)
-  (go *driver* "http://google.com")
+  (e/connect-driver *driver*)
+  (e/go *driver* "http://google.com")
   (f)
-  (disconnect-driver *driver*))
+  (e/disconnect-driver *driver*))
 
 ;; this is run `once` before running the tests
 (use-fixtures
@@ -1795,20 +2375,21 @@ If for some reason you want to use a single instance, you can use fixtures like 
 
 For faster testing you can use this example:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 .....
 
 (defn fixture-browser [f]
-  (with-chrome-headless {:args ["--no-sandbox"]} driver
+  (e2/with-chrome-headless [driver {:args ["--no-sandbox"]}]
     (binding [*driver* driver]
       (f))))
 
 ;; note that resources, such as cookies, are deleted manually,
 ;; so this does not guarantee that the tests are clean
 (defn fixture-clear-browser [f]
-  (delete-cookies *driver*)
-  (go *driver* "http://google.com")
+  (e/delete-cookies *driver*)
+  (e/go *driver* "http://google.com")
   (f))
 
 ......
@@ -1820,6 +2401,7 @@ In the example above, we examined a case when you run tests against a single typ
 However, you may want to test your site on multiple drivers, say, Chrome and Firefox.
 In that case, your fixture may become a bit more complex:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 
@@ -1827,36 +2409,41 @@ In that case, your fixture may become a bit more complex:
 
 (defn fixture-drivers [f]
   (doseq [type driver-types]
-    (with-driver type {} driver
+    (e/with-driver type {} driver
       (binding [*driver* driver]
         (testing (format "Testing in %s browser" (name type))
           (f))))))
 ----
 
-Now, each test will be run twice in both Firefox and Chrome browsers.
+Now, each test will be run twice.
+Once for Firefox and then once Chrome.
 Please note the test call is prepended with `testing` macro that puts driver name into the report.
 Once you've got an error, you'll easy find what driver failed the tests exactly.
 
+TIP: See also link:{url-tests}[Etaoin's API tests] for an example of this strategy.
+
 === Postmortem Handler To Collect Artifacts
 
-To save some artifacts in case of exception, wrap the body of your test into `with-postmortem` handler as follows:
+To save some artifacts in case of an exception, wrap the body of your test into `with-postmortem` handler as follows:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 (deftest test-user-login
-  (with-postmortem *driver* {:dir "/path/to/folder"}
+  (e/with-postmortem *driver* {:dir "/path/to/folder"}
     (doto *driver*
-      (go "http://127.0.0.1:8080")
-      (click-visible :login)
+      (e/go "http://127.0.0.1:8080")
+      (e/click-visible :login)
       ;; any other actions...
       )))
 ----
 
 Now that, if any exception occurs in that test, artifacts will be saved.
 
-To not copy and paste the options map, declare it on the top of the module.
+To not copy and paste the options map, declare it on at the top of the module.
 If you use Circle CI, it would be great to save the data into a special artifacts directory that might be downloaded as a zip file once the build has been finished:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 (def pm-dir
@@ -1869,24 +2456,28 @@ If you use Circle CI, it would be great to save the data into a special artifact
 
 Now pass that map everywhere into PM handler:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
   ;; test declaration
-  (with-postmortem *driver* pm-opt
+  (e/with-postmortem *driver* pm-opt
     ;; test body goes here
     )
 ----
 
 Once an error occurs, you will find a PNG image that represents your browser page at the moment of exception and HTML dump.
 
+See <<postmortem>>.
+
 === Running Tests By Tag
 
 Since UI tests may take lots of time to pass, it's definitely a good practice to pass both server and UI tests independently from each other.
 
-If you are using lneiningen, here are a few tips.
+If you are using leiningen, here are a few tips.
 
 First, add `+^:integration+` tag to all the tests that are run under the browser like follows:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
 (deftest ^:integration
@@ -1894,7 +2485,8 @@ First, add `+^:integration+` tag to all the tests that are run under the browser
   (doto *driver*
     (go url-password-reset)
     (click :reset-btn)
-    ...
+    ;; and so on...
+  ))
 ----
 
 Then, open your `project.clj` file and add test selectors:
@@ -1905,21 +2497,16 @@ Then, open your `project.clj` file and add test selectors:
                  :integration :integration}
 ----
 
-Now, once you launch `lein test` you will run all the tests except browser ones.
+Now, when you launch `lein test` you will run all the tests except browser integration tests.
 To run integration tests, launch `lein test :integration`.
 
-The main difference between a program and a human is that the first one operates very fast.
-It means so fast, that sometimes a browser cannot render new HTML in time.
-So after each action you need to put `wait-<something>` function that just polls a browser checking for a predicate.
-Or just `(wait <seconds>)` if you don't care about optimization.
+=== Check Whether a File has been Downloaded [[test-file-downloads]]
 
-=== Check whether a file has been downloaded
-
-Sometimes, a file starts to download automatically once you clicked on a link or just visited some page.
-In tests, you need to ensure a file really has been downloaded successfully.
+Sometimes, a file starts to download automatically when you click on a link or just visit some page.
+In tests, you might need to ensure a file really has been downloaded successfully.
 A common scenario would be:
 
-* provide a custom empty download folder when running a browser (see above).
+* provide a custom empty download folder when running a browser (see <<download-dir>>).
 * Click on a link or perform any action needed to start file downloading.
 * Wait for some time;
 for small files, 5-10 seconds would be enough.
@@ -1928,8 +2515,12 @@ Check if it matches a proper extension, name, creation date, etc.
 
 Example:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
+(require '[clojure.java.io :as io]
+         '[clojure.string :as str])
+
 ;; Local helper that checks whether it is really an Excel file.
 (defn xlsx? [file]
   (-> file
@@ -1938,11 +2529,11 @@ Example:
 
 ;; Top-level declarations
 (def DL-DIR "/Users/ivan/Desktop")
-(def driver (chrome {:download-dir DL-DIR}))
+(def driver (e/chrome {:download-dir DL-DIR}))
 
 ;; Later, in tests...
-(click-visible driver :download-that-application)
-(wait driver 7) ;; wait for a file has been downloaded
+(e/click-visible driver :download-that-application)
+(e/wait driver 7) ;; wait for a file has been downloaded
 
 ;; Now, scan the directory and try to find a file:
 (let [files (file-seq (io/file DL-DIR))
@@ -1954,20 +2545,23 @@ Example:
 == Running Selenium IDE files
 
 Etaoin can play the files produced by link:{ide}[Selenium IDE].
-It's an official utility to create scenarios interactively.
-The IDE comes as an extension to your browser.
-Once installed, it records you actions into a JSON file with the `.side` extension.
+Selenium IDE allows you to record web interactions for later playback.
+It is installed as an optional extension in your web browser.
+
+Once installed, and activated, it records your actions into a JSON file with the `.side` extension.
 You can save that file and run it with Etaoin.
 
-Let's imagine you've installed the IDE and recorded some actions as the official documentation prescribes.
-Now that you have a `test.side` file, do this:
+Let's imagine you've installed the IDE and recorded some actions as per Selenium IDE documentation.
+Now that you have a `test.side` file, you could do something like this:
 
+//:test-doc-blocks/skip
 [source,clojure]
 ----
+(require '[clojure.java.io :as io]
+         '[etaoin.api :as e]
+         '[etaoin.ide.flow :as flow])
 
-(require '[etaoin.ide.flow :as flow])
-
-(def driver (chrome))
+(def driver (e/chrome))
 
 (def ide-file (io/resource "ide/test.side"))
 
@@ -1997,11 +2591,11 @@ Now that you have a `test.side` file, do this:
 (flow/run-ide-script driver ide-file opt)
 ----
 
-Everything related to the IDE is stored under the `etaoin.ide` package.
+Everything related to the IDE feature can be found under the link:{url-doc}/CURRENT/api/etaoin.ide[etaoin.ide] namespace.
 
-=== CLI arguments
+=== CLI Arguments
 
-You may also run a script from the command line.
+You may also run a `.side` script from the command line.
 Here is a `clojure` example:
 
 [source,shell]
@@ -2033,7 +2627,7 @@ We support the following arguments (check them out using the `clojure -M -m etao
   -h, --help
 ----
 
-Pay attention to the `--params` one.
+Pay attention to `--params`.
 This must be an EDN string representing a Clojure map.
 That's the same map that you pass into a driver when initiate it.
 
@@ -2041,162 +2635,160 @@ Please note the IDE support is still experimental.
 If you encounter unexpected behavior feel free to open an issue.
 At the moment, we only support Chrome and Firefox for IDE files.
 
-== Troubleshooting [[troubleshooting]]
+== Webdriver in Docker
 
-=== Calling maximize function throws an error
+To work with the driver in Docker, you can take ready-made images:
 
-Example:
+Example for https://hub.docker.com/r/robcherry/docker-chromedriver/[Chrome]:
 
+[source,shell]
+----
+docker run --name chromedriver -p 9515:4444 -d -e CHROMEDRIVER_WHITELISTED_IPS='' robcherry/docker-chromedriver:latest
+----
+
+for https://hub.docker.com/r/instrumentisto/geckodriver[Firefox]:
+
+[source,shell]
+----
+docker run --name geckodriver -p 4444:4444 -d instrumentisto/geckodriver
+----
+
+To connect to an exisiting running WebDriver process you need to specify the `:host`.
+In this example `:host` would be `localhost` or `127.0.0.1`.
+The `:port` would be the appropirate port for the running WebDriver process as exposed by docker.
+If the port is not specified, the <<parameters,default>> port is set.
+
+//:test-doc-blocks/skip
 [source,clojure]
 ----
-etaoin.api> (def driver (chrome))
-#'etaoin.api/driver
-etaoin.api> (maximize driver)
-ExceptionInfo throw+: {:response {
-:sessionId "2672b934de785aabb730fd19330cf40c",
-:status 13,
-:value {:message "unknown error: cannot get automation extension\nfrom unknown error: page could not be found: chrome-extension://aapnijgdinlhnhlmodcfapnahmbfebeb/_generated_background_page.html\n
-(Session info: chrome=57.0.2987.133)\n  (Driver info: chromedriver=2.27.440174
-(e97a722caafc2d3a8b807ee115bfb307f7d2cfd9),platform=Mac OS X 10.11.6 x86_64)"}},
-...
+(def driver (e/chrome-headless {:host "localhost" :port 9515 :args ["--no-sandbox"]}))
+(def driver (e/firefox-headless {:host "localhost"})) ;; will try to connect to port 4444
 ----
 
-*Solution:* just update your `chromedriver` to the last version.
-Tested with 2.29, works fine.
-People say it woks as well since 2.28.
+== Troubleshooting [[troubleshooting]]
 
-:maximize-issue: https://github.com/SeleniumHQ/selenium/issues/3508
-:chromedriver-dl: https://sites.google.com/a/chromium.org/chromedriver/downloads
+=== Old Versions of WebDrivers can have Limitations
 
-Remember, `brew` package manager has the outdated version 2.27.
-You will probably have to download binaries from the link:{chromedriver-dl}[official site].
+[horizontal]
+Reproduction:: For example, `chromedriver` used to throw an error when calling `maximize`:
++
+[source,clojure]
+----
+(e2/with-chrome [driver]
+  (e/maximize driver))
+;; an exception with "cannot get automation extension" was thrown
+----
+Cause:: This was a bug in `chromedriver` that was fixed in chromdriver v2.28.
+Solution:: Updating to the current WebDriver resolved the issue.
 
-See the link:{maximize-issue}[related issue] in Selenium project.
+=== XPath and Searching from Root vs Current node
 
-=== Querying wrong elements with XPath expressions
-
-When passing a vector-like query, say `[{:tag :p} "//*[text()='foo')]]"}]` be careful with hand-written XPath expressions.
-In vector, every its expression searches from the previous one in a loop.
-There is a hidden mistake here: without a leading dot, the `+"//..."+` clause means to find an element from the root of the whole page.
+Reproduction::
++
+[source,clojure]
+----
+;; we intend to find an element with the text 'some' under an element with id 'mishmash'
+(e/get-element-text driver [{:id :mishmash} "//*[contains(text(),'some')]"])
+;; => "A little sample page to illustrate some concepts described in the Etaoin user guide."
+;; but we've found the first element with text 'some'
+----
+Cause:: In a vector, every expression searches from the previous one in a loop.
+Without a leading dot, the XPath `+"//..."+` clause means to find an element from the root of the whole page.
 With a dot, it means to find from the current node, which is one from the previous query, and so forth.
-
-That's why, it's easy to select something completely different that what you would like.
-A proper expression would be: `[{:tag :p} ".//*[text()='foo')]]"}]`.
+Solution:: Add the XPath dot.
++
+[source,clojure]
+----
+(e/get-element-text driver [{:id :mishmash} ".//*[contains(text(),'some')]"])
+;; => "some other paragraph"
+;; that's what we were looking for!
+----
 
 === Clicking On Non-Visible Element
 
-Example:
-
+Reproduction::
+//:test-doc-blocks/skip
++
 [source,clojure]
 ----
-etaoin.api> (click driver :some-id)
-ExceptionInfo throw+: {:response {
-:sessionId "d112ce8ddb49accdae78a769d5809eae",
-:status 11,
-:value {:message "element not visible\n  (Session info: chrome=57.0.2987.133)\n
-(Driver info: chromedriver=2.29.461585
-(0be2cd95f834e9ee7c46bcc7cf405b483f5ae83b),platform=Mac OS X 10.11.6 x86_64)"}},
-...
+(e/click driver :cantseeme)
+;; as of this writing, on chrome throws an exception with message containing 'not interactable'
 ----
 
-*Solution:* you are trying to click an element that is not visible or its dimentions are as little as it's impossible for a human to click on it.
-You should pass another selector.
+Cause:: You cannot interact with an element that is not visible or is so small that a human could not click on it.
+
+=== Selectors not Working
+
+Symptom:: Selectors for locating element are not working, even though the elements are clearly available.
+
+Possible cause:: Your script may have clicked a link that opened a new tab or window.
+Even though the new window is in the foreground, the driver instance is still connected to the original window.
+
+Solution:: Call `switch-window-next` when a new tab or window is opened to point the driver to the new tab/window.
 
 === Unpredictable errors in Chrome when window is not active
 
-*Problem:* when you focus on other window, webdriver session that is run under Google Chrome fails.
+Reproduction:: when you focus on another window, a WebDriver session that is run under Google Chrome fails.
 
-*Solution:* Google Chrome may suspend a tab when it has been inactive for some time.
-When the page is suspended, no operation could be done on it.
+Solution:: Google Chrome may suspend a tab when it has been inactive for some time.
+When the page is suspended, no operation can be done on it.
 No clicks, Js execution, etc.
 So try to keep Chrome window active during test session.
 
-=== Invalid argument: can't kill an exited process
+=== Invalid argument: can't kill an exited process for Firefox
 
-*Problem:* When you try to start the driver you get an error:
-
+Reproduction:: When you try to start the driver you get an error:
+//:test-doc-blocks/skip
++
 [source,clojure]
 ----
-user=> (use 'etaoin.api)
-user=> (def driver (firefox {:headless true}))
+(def driver (e/firefox {:headless true}))
+;; throws an exception containing message with 'invalid argument: can't kill an exited process'
 ----
 
-____
-Syntax error (ExceptionInfo) compiling at (REPL:1:13).
-throw+: {:response {:value {:error "unknown error", :message "invalid argument: can't kill an exited process"....
-____
+Possible Cause:: Running Firefox as root in a regular user's session is not supported
 
-Possible cause: "Running Firefox as root in a regular user's session is not supported"
-
-*Solution:* To check, run the driver with the path to the log files and the "trace" log level and explore their output.
-
+To Diagnose:: Run the driver with the path to the log files and the "trace" log level and explore the output.
+//:test-doc-blocks/skip
++
 [source,clojure]
 ----
 (def driver (firefox {:log-stdout "ffout.log" :log-stderr "fferr.log" :driver-log-level "trace"}))
 ----
+Similar Problem:: https://github.com/mozilla/geckodriver/issues/1655
 
-Similar problem: https://github.com/mozilla/geckodriver/issues/1655
+=== DevToolsActivePort file doesn't exist error on Chrome
 
-=== DevToolsActivePort file doesn't exist
+Reproduction:: When you try to start the chromedriver you get an error:
 
-*Problem:* When you try to start the chromedriver you get an error:
+//:test-doc-blocks/skip
+[source,clojure]
+----
+(def driver (e/chrome))
+;; throws an exception with message containing 'DevToolsActivePort file doesn't exist'
+----
 
-____
-clojure.lang.ExceptionInfo: throw+: {:response {:sessionId ".....", :status 13, :value {:message "unknown error: Chrome failed to start: exited abnormally.\n  (unknown error: DevToolsActivePort file doesn't exist)...
-____
-
-Possible cause:
-
-____
+Possible Cause::
 A common cause for Chrome to crash during startup is running Chrome as root user (administrator) on Linux.
 While it is possible to work around this issue by passing --no-sandbox flag when creating your WebDriver session, such a configuration is unsupported and highly discouraged.
 You need to configure your environment to run Chrome as a regular user instead.
-____
 
-*Solution:* Run driver with an argument `--no-sandbox`.
+Potential Solution:: Run driver with an argument `--no-sandbox`.
 Caution!
-This is a bypass OS security model.
-
+This bypasses OS security model.
++
 [source,clojure]
 ----
-(def driver (chrome {:args ["--no-sandbox"]}))
+(e2/with-chrome [driver {:args ["--no-sandbox"]}]
+  (e/go driver "https://clojure.org"))
 ----
 
-A similar problem is described https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t[here]
+Similiar Problem:: A similar problem is described https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t[here]
 
-
-=== Selectors not working
-
-*Problem:* Selectors for locating element are not working, even though the elements are clearly available.
-
-Possible cause: Your script may have clicked a link that opened a new tab or window.
-Even though the new window is in the foreground, the driver instance is still connected to the original window.
-
-*Solution:* Call `switch-window-next` when a new tab or window is opened to point the driver to the new tab/window.
-
-
-== API v2
-
-The `etaoin.api2` namespace brings some bits of alternative macros and functions.
-They provide better syntax and live in a separate namespace to prevent the old API from breaking.
-
-At the moment, the `api2` module provides a set of `+with-...+` macros with a `let`-like binding form:
-
+// A little invisible cheat to cleanup our driver
+ifdef::env-test-doc-blocks[]
 [source,clojure]
 ----
-(ns ...
-  (:require
-   [etaoin.api :as api]
-   [etaoin.api2 :as api2]))
-
-(api2/with-chrome [driver {}]
-  (api/go driver "http://ya.ru"))
+(e/quit driver)
 ----
-
-The options map can be skipped so you have only a binding symbol:
-
-[source,clojure]
-----
-(api2/with-firefox [ff]
-  (api/go ff "http://ya.ru"))
-----
+endif::[]

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -7,9 +7,9 @@
 :project-src-coords: clj-commons/etaoin
 :project-mvn-coords: etaoin/etaoin
 :url-webdriver: https://www.w3.org/TR/webdriver/
-:url-sample-page: http://{project-src-coords}/doc/user-guide-sample.html
+:url-sample-page: /doc/user-guide-sample.html
 :url-doc: https://cljdoc.org/d/{project-mvn-coords}
-:url-tests: https://github.com/{project-src-coords}/blob/master/test/etaoin/api_test.clj
+:url-tests: /test/etaoin/api_test.clj
 :url-slack: https://clojurians.slack.com/archives/C7KDM0EKW
 
 == Introduction
@@ -22,7 +22,8 @@ It is a thin abstraction atop the link:{url-webdriver}[W3C WebDriver protocol] t
 Ivan Grishaev (https://github.com/igrishaev[@igrishaev]) created Etaoin and published its first release to Clojars in Feb of 2017.
 He and his band of faithful contributors grew Etaoin into a well respected goto-library for browser automation.
 
-In May of 2022, finding his time had gravitated more to back-end development, Ivan offered Etaoin for adoption to clj-commons where it is now currently under the loving care of https://github.com/lread[@lread] and https://github.com/borkdude[@borkdude].
+In May 2022, finding his time had gravitated more to back-end development, Ivan offered Etaoin for adoption to clj-commons.
+It is now currently under the loving care of https://github.com/lread[@lread] and https://github.com/borkdude[@borkdude].
 
 === Interesting Alternatives
 
@@ -58,14 +59,14 @@ Etaoin's test suite covers the following OSes and browsers for both Clojure and 
 
 |===
 
-NOTE: At one point we did also test against PhantomJS, but since work has long ago stopped on this project we have dropped testing.
+NOTE: We once did test against PhantomJS, but since work has long ago stopped on this project, we have dropped testing
 
 == Installation
 
 There are two steps to installation:
 
 . Add the `etaoin` library as a dependency to your project
-. Install the WebDriver for each web browser you'd like control with Etaoin
+. Install the WebDriver for each web browser that you want to control with Etaoin
 
 === Installing the Etaoin Library
 
@@ -124,11 +125,12 @@ See https://github.com/babashka/spec.alpha[babashka/spec.alpha] for current docs
 === Installing the Browser WebDrivers
 
 Etaoin controls web browsers via their WebDrivers.
-Each browser has its own WebDriver implementation which must be installed.
+Each browser has its own WebDriver implementation that must be installed.
 
 [TIP]
 ====
-If it is not already installed, download the web browser you'd like to control (Chrome, Firefox, Edge) as per normal - which is usually by downloading it from its official site.
+If it is not already installed, you will need to install the web browser too (Chrome, Firefox, Edge).
+This is usually via a download from its official site.
 Safari comes bundled with macOS.
 ====
 
@@ -166,7 +168,9 @@ Edge and `msedgedriver` must match so you might need to specify the version:
 ** Windows: `scoop install phantomjs`
 ** Download: link:{url-phantom-dl}[Official PhantomJS download site]
 
-Now, check your installation launching any of these commands. For each command, an endless process with a local HTTP server should start.
+Check your WebDriver installations launching by launching these commands.
+Each should start a process that includes its own local HTTP server.
+Use Ctrl-C to terminate.
 
 [source,bash]
 ----
@@ -177,9 +181,10 @@ msedgedriver
 phantomjs --wd
 ----
 
-If you like, you can run Etaoin's test suite to verify your installation.
+You can optionally run the Etaoin test suite to verify your installation.
 
-TIP: Some Etaoin API tests rely on ImageMagick, install it prior to running test.
+TIP: Some Etaoin API tests rely on ImageMagick.
+Install it prior to running test.
 
 From a clone of the https://github.com/clj-commons/etaoin[Etaoin GitHub repo]
 
@@ -202,8 +207,8 @@ bb test all
 bb test api --browser chrome
 ----
 
-When tests are running, you'll see browser windows open and close in series.
-The tests use a local HTML file with a special layout to validate most interactions.
+During the test run, browser windows will open and close in series.
+The tests use a local handcrafted HTML file to validate most interactions.
 
 See <<troubleshooting>> if you have problems - or reach out on link:{url-slack}[Clojurians Slack #etaoin] or https://github.com/clj-commons/etaoin/issues[GitHub issues].
 
@@ -296,11 +301,13 @@ A portion of the above rewritten with `doto`:
 == Playing Along in your REPL
 We encourage you to try the examples in from this user guide in your REPL.
 
-The Interwebs is in constant change, so while using live sites is attractive, this code in this user guide has instead been tested to work against our link:{url-sample-page}[little sample page].
+The Interwebs is constantly changing.
+This makes testing against live sites impractical.
+The code in this user guide has instead been tested to work against our link:{url-sample-page}[little sample page].
 
 Until we figure out something more clever, it might be easiest to clone the etaoin GitHub repository and run a REPL from there.
 
-Unless otherwise directed, our examples throughout the rest of this guide will assume you've already done the equivalent of:
+Unless otherwise directed, our examples throughout the rest of this guide will assume you've already executed the equivalent of:
 
 [source,clojure]
 ----
@@ -363,7 +370,7 @@ This will ensure that the WebDriver process is closed regardless of what happens
 
 == Unit Tests as Docs
 
-The sections that follow describe, how to use Etaoin in more depth.
+The sections that follow describe how to use Etaoin in more depth.
 
 In addition to these docs, the link:{url-tests}[Etaoin api tests] are also a good reference.
 
@@ -413,7 +420,7 @@ The v2 API has ergonomic `with-<browser>` functions that handle cleanup nicely:
 Replace `chrome` with `firefox`, `edge` or `safari` for other variants.
 See link:{url-doc}[API docs] for details.
 
-See <<parameters>> for all options available when creating a driver
+See <<parameters>> for all options available when creating a driver.
 
 == Selecting Elements [[querying]]
 
@@ -431,7 +438,7 @@ Queries (aka selectors) are used to select the elements on the page that Etaoin 
 
 [TIP]
 ====
-* A query returns a unique element identifier that is typically meaningful only as a selector to other functions it is passed to.
+* A query returns a unique element identifier typically meaningful only as a selector to other functions it is passed to.
 * Many functions accept a query directly. For example:
 +
 [source,clojure]]
@@ -447,8 +454,8 @@ Queries (aka selectors) are used to select the elements on the page that Etaoin 
 
 [TIP]
 ====
-If a query does not find the element, an exception will be thrown.
-Use `exists?` to check if a query returns an element.
+An exception is thrown if a query does not find an element.
+Use exists? to check for element existence:
 
 [source,clojure]
 ----
@@ -465,7 +472,7 @@ Use `exists?` to check if a query returns an element.
 :css-sel: https://www.w3schools.com/cssref/css_selectors.asp
 
 * `:active` finds the current active element.
-The Google page, for example, automatically places the focus on the main search input.
+The Google page, for example, automatically places the focus on the search input.
 So there is no need to click on it first:
 +
 [source,clojure]
@@ -523,7 +530,7 @@ Defaults to `*`.
 * An `:index` key expands into the trailing XPath `[x]` clause.
 Useful when you need to select a third row from a table, for example.
 * Any non-special key represents an attribute and its value.
-* A special key has `:fn/` namespace and expands into something specific.
+* `:fn/` is a prefix followed by a supported query function.
 
 Examples:
 
@@ -743,8 +750,8 @@ Notice:
 ==== Querying a Tree
 
 `query-tree` pipes selectors.
-Every next selector queries elements from the previous one.
-The fist selector finds elements from the root, subsquent selectors find elements downward from each of the previous found elements.
+Every selector queries elements from the previous one.
+The first selector finds elements from the root, subsquent selectors find elements downward from each of the previous found elements.
 
 Given the following HTML:
 [source,html]
@@ -859,7 +866,7 @@ It acts the same but raises an exception when querying the page returns multiple
 
 Although double-clicking is rarely purposefully employed on web sites, some naive users might think it is the correct way to click on a button or link.
 
-A double click can be simulated with `double-click` function (Chrome, Phantom.js).
+A double-click can be simulated with `double-click` function (Chrome, Phantom.js).
 It can be used, for example, to check your handling of disallowing multiple form submissions.
 
 [source,clojure]
@@ -886,7 +893,7 @@ Another set of functions do the same but move the mouse pointer to a specified e
 (e/right-click-on driver {:tag :a})
 ----
 
-A middle mouse click is useful to open a link in a new background tab.
+A middle mouse click can open a link in a new background tab.
 The right click sometimes is used to imitate a context menu in web applications.
 
 === Keyboard Chords
@@ -938,16 +945,16 @@ Finally, you press delete to clear the selected text:
 
 There are also `with-ctrl` and `with-command` functions that act as you would expect.
 
-NOTE: Pay attention, these functions do not apply to the global browser's shortcuts.
+NOTE: These functions do not apply to the global browser's shortcuts.
 For example, neither "Command + R" nor "Command + T" reload the page or open a new tab.
 
 All the `etaoin.keys/with-*` functions are just wrappers upon the `etaoin.keys/chord` function that might be used for complex cases.
 
 === File Uploading
 
-Clicking on a file input button opens an OS-specific dialog that you are not allowed to interact with using WebDriver protocol.
+Clicking on a file input button opens an OS-specific dialog.
+You technically cannot interact with this dialog using the WebDriver protocol.
 Use the `upload-file` function to attach a local file to a file input widget.
-The function takes a selector that points to a file input and either path as a string or a native `java.io.File` instance.
 An exception will be thrown if the local file is not found.
 
 [source,clojure]
@@ -1088,7 +1095,7 @@ To reach nested frames, you can dig down like so:
 (e/switch-frame-parent driver)
 ----
 
-You can also use the `with-frame` macro to temporarily switch to a target frame, do some work, returning its last expression, all while preserving your original frame context.
+Use the `with-frame` macro to temporarily switch to a target frame, do some work, returning its last expression, while preserving your original frame context.
 
 [source,clojure]
 ----
@@ -1108,7 +1115,7 @@ Use `js-execute` to evaluate a Javascript code in the browser:
 (e/dismiss-alert driver)
 ----
 
-Pass any additional parameters into the call inside a script with the `arguments` array-like object.
+Pass any additional parameters to the script with the `arguments` array-like object.
 [source,clojure]
 ----
 (e/js-execute driver "alert(arguments[2].foo)" 1 false {:foo "hello again!"})
@@ -1137,9 +1144,9 @@ Notice that the JSON has been automatically converted to edn.
 
 ==== Asynchronous Scripts
 
-If your script performs AJAX requests or operates on `setTimeout` or any other async strategies, you cannot just `return` the result.
-Instead, a special callback must be called against the data you'd like to resolve.
-The WebDriver passes this callback by adding it as the last argument for your script.
+Use `js-async` to deal with scripts that rely on async strategies such as `setTimeout`.
+The WebDriver creates and passes a callback as the last argument to your script.
+To indicate that work is complete, you must call this callback.
 
 Example:
 
@@ -1187,7 +1194,7 @@ or for a block of code via `with-script-timeout`:
 
 The main difference between a program and a human being is that the first one operates very fast.
 A computer operates so fast, that sometimes a browser cannot render new HTML in time.
-After each action, you might consider including a `wait-<something>` function that polls a browser until the predicate evaluates into true.
+After each action, you might consider including a `wait-<something>` function that polls a browser until the predicate evaluates to true.
 Or just `(wait <seconds>)` if you don't care about optimization.
 
 The `with-wait` macro might be helpful when you need to prepend each action with `(wait n)`.
@@ -1195,7 +1202,7 @@ For example, the following form:
 
 [source,clojure]
 ----
-(e/with-wait 1 
+(e/with-wait 1
   (e/refresh driver)
   (e/fill driver :uname "my username")
   (e/fill driver :text "some text"))
@@ -1273,7 +1280,7 @@ Wait text:
 === Load Strategy [[load-strategy]]
 
 When you navigate to a page, the driver waits until the whole page has been completely loaded.
-What's fine in most cases, but doesn't reflect the way human beings interact with the Internet.
+That's fine in most cases but doesn't reflect the way human beings interact with the Internet.
 
 Change this default behavior with the `:load-strategy` option:
 
@@ -1435,8 +1442,8 @@ or a `File` object:
 
 === Screenshots for Specific Elements
 
-With Firefox and Chrome, you can also capture a single element within a page, say a div, an input widget or whatever.
-It doesn't work with other browsers as this time.
+With Firefox and Chrome, you can also capture a single element within a page, say a div, an input widget, or whatever.
+It doesn't work with other browsers at this time.
 
 [source,clojure]
 ----
@@ -1446,7 +1453,7 @@ It doesn't work with other browsers as this time.
 === Screenshots after each form
 
 Use `with-screenshots` to take a screenshot to the specified directory after each form is executed in the code block.
-The filenaming convention is `<webdriver-name>-<milliseconds-since-1970>.png`
+The file naming convention is `<webdriver-name>-<milliseconds-since-1970>.png`
 
 [source,clojure]
 ----
@@ -1508,9 +1515,9 @@ Phantom.js wipes the logs when the page location changes.
 
 === DevTools: Tracking HTTP Requests, XHR (Ajax)
 
-You can trace events which come from the DevTools panel.
+You can trace events that come from the DevTools panel.
 This means that everything you see in the developer console now is available through the Etaoin API.
-This currenty only works for Google Chrome.
+This currently only works for Google Chrome.
 
 To start a driver with devtools support enabled specify a `:dev` map.
 
@@ -1747,7 +1754,7 @@ To check if a request has been finished, done or failed, use these predicates:
 Note that `request-done?` doesn't mean the request has succeeded.
 It only means its pipeline has reached a final step.
 
-TIP: when you read dev logs, you consume them from an internal buffer which gets flushed.
+TIP: when you read dev logs, you consume them from an internal buffer that gets flushed.
 The second call to `get-requests` or `get-ajax` will return an empty list.
 
 Perhaps you want to collect these logs.
@@ -1823,8 +1830,8 @@ Unlike `get-requests` and `get-ajax`, they are pure functions and won't flush an
 ;;     :done? true}
 ----
 
-When working with logs and requests, pay attention it their count and size.
-The maps have plenty of keys and the amount of items in collections came be very large.
+When working with logs and requests, pay attention to their count and size.
+The maps have plenty of keys and the number of items in collections can become very large.
 Printing a slew of events might freeze your editor.
 Consider using `clojure.pprint/pprint` as it relies on max level and length limits.
 
@@ -1959,7 +1966,7 @@ Example: `:args ["--incognito" "--app" "http://example.com"]`
 | <not set>
 
 a| `:log-level` *web browser* minimal console log level.
-Only message with this level and above will be collected.
+Only messages with this level and above will be collected.
 From least to most verbose:
 
 * `nil`, `:off` or `:none` for no messages
@@ -2055,24 +2062,24 @@ Example: `:load-strategy :none`
 
 | `:capabilities` *WebDriver*-specific options.
 Read vendor docs for WebDriver before setting anything here.
-You'll find an example ussage under <<http-proxy>>.
+You'll find an example usage under <<http-proxy>>.
 | <none>
 
 |===
 
 === Using Headless Drivers [[headless]]
 
-Google Chrome, Firefox and Microsoft Edge can be run in headless mode.
-When headless, none of UI windows appear on the screen.
+Google Chrome, Firefox, and Microsoft Edge can be run in headless mode.
+When headless, none of the UI windows appear on the screen.
 Running without a UI is helpful when:
 
-* running integration tests on servers that do not have graphical output device
+* running integration tests on servers that do not have a graphical output device
 * running local tests without having them take over your local UI
 
-Ensure your browser supports headless mode by checking if it accepts `--headless` command line argument when running it from the terminal.
+Ensure your browser supports headless mode by checking if it accepts `--headless` command-line argument when running it from the terminal.
 The Phantom.js driver is headless by its nature (it was never been developed for rendering UI).
 
-When starting a driver, pass `:headless` boolean flag to switch into headless mode.
+When starting a driver, pass the `:headless` boolean flag to switch into headless mode.
 This flag is ignored for Safari which, as of June 2022, still does not support headless mode.
 
 //{:test-doc-blocks/test-ns user-guide-headless-test}
@@ -2125,7 +2132,7 @@ There are several shortcuts to run Chrome or Firefox in headless mode:
   (e/go driver "https://clojure.org"))
 ----
 
-There are also `when-headless` and `when-not-headless` macros that allow to perform a block of commands only if a browser is in headless mode or not respectively:
+There are also the `when-headless` and `when-not-headless` macros that conditonally execute a block of commands:
 
 //{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
@@ -2180,7 +2187,7 @@ Set a custom `User-Agent` header with the `:user-agent` option when creating a d
 ;; => "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
 ----
 
-Setting this header is important when using <<headless,headless browsers>> as many web sites implement some sort of blocking when the User-Agent includes the "headless" string.
+Setting this header is important when using <<headless,headless browsers>> as many websites implement some sort of blocking when the User-Agent includes the "headless" string.
 This can lead to 403 response or some weird behavior of the site.
 
 === HTTP Proxy [[http-proxy]]
@@ -2245,7 +2252,7 @@ Example:
 === Setting the Browser Profile [[browser-profile]]
 
 When running Chrome or Firefox, you may specify a special web browser profile made for test purposes.
-A profile is a folder that keeps browser settings, history, bookmarks and other user-specific data.
+A profile is a folder that keeps browser settings, history, bookmarks, and other user-specific data.
 
 Imagine, for example, that you'd like to run your integration tests against a user that turned off Javascript execution or image rendering.
 
@@ -2421,14 +2428,14 @@ In that case, your fixture may become a bit more complex:
 
 Now, each test will be run twice.
 Once for Firefox and then once Chrome.
-Please note the test call is prepended with `testing` macro that puts driver name into the report.
-Once you've got an error, you'll easy find what driver failed the tests exactly.
+Please note the test call is prepended with the `testing` macro that puts the driver name into the report.
+Once you've got an error, you'll easily find what driver failed the tests exactly.
 
 TIP: See also link:{url-tests}[Etaoin's API tests] for an example of this strategy.
 
 === Postmortem Handler To Collect Artifacts
 
-To save some artifacts in case of an exception, wrap the body of your test into `with-postmortem` handler as follows:
+To save some artifacts in case of an exception, wrap the body of your test into the `with-postmortem` handler as follows:
 
 //:test-doc-blocks/skip
 [source,clojure]
@@ -2442,9 +2449,9 @@ To save some artifacts in case of an exception, wrap the body of your test into 
       )))
 ----
 
-Now that, if any exception occurs in that test, artifacts will be saved.
+If any exception occurs in that test, artifacts will be saved.
 
-To not copy and paste the options map, declare it on at the top of the module.
+To not copy and paste the options map, declare it at the top of the module.
 If you use Circle CI, it would be great to save the data into a special artifacts directory that might be downloaded as a zip file once the build has been finished:
 
 //:test-doc-blocks/skip
@@ -2633,7 +2640,7 @@ We support the following arguments (check them out using the `clojure -M -m etao
 
 Pay attention to `--params`.
 This must be an EDN string representing a Clojure map.
-That's the same map that you pass into a driver when initiate it.
+That's the same map that you pass into a driver at creation time.
 
 Please note the IDE support is still experimental.
 If you encounter unexpected behavior feel free to open an issue.
@@ -2657,7 +2664,7 @@ for https://hub.docker.com/r/instrumentisto/geckodriver[Firefox]:
 docker run --name geckodriver -p 4444:4444 -d instrumentisto/geckodriver
 ----
 
-To connect to an exisiting running WebDriver process you need to specify the `:host`.
+To connect to an existing running WebDriver process you need to specify the `:host`.
 In this example `:host` would be `localhost` or `127.0.0.1`.
 The `:port` would be the appropirate port for the running WebDriver process as exposed by docker.
 If the port is not specified, the <<parameters,default>> port is set.
@@ -2723,14 +2730,14 @@ Cause:: You cannot interact with an element that is not visible or is so small t
 
 === Selectors not Working
 
-Symptom:: Selectors for locating element are not working, even though the elements are clearly available.
+Symptom:: Selectors for locating elements are not working, even though the elements are clearly available.
 
 Possible cause:: Your script may have clicked a link that opened a new tab or window.
 Even though the new window is in the foreground, the driver instance is still connected to the original window.
 
 Solution:: Call `switch-window-next` when a new tab or window is opened to point the driver to the new tab/window.
 
-=== Unpredictable errors in Chrome when window is not active
+=== Unpredictable errors in Chrome when the window is not active
 
 Reproduction:: when you focus on another window, a WebDriver session that is run under Google Chrome fails.
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -913,6 +913,7 @@ A quick example of entering ordinary characters while holding Shift:
 [source,clojure]
 ----
 (e/refresh driver)
+(e/wait 1) ;; maybe we need a sec for active element to focus
 (e/fill-active driver (k/with-shift "caps is great"))
 (e/get-element-value driver :active)
 ;; => "CAPS IS GREAT"

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -67,6 +67,9 @@ All documentation is written in AsciiDoc.
 
 We host our docs on cljdoc and have support for <<cljdoc-preview,previewing>>
 
+
+
+
 == Babashka Tasks
 
 We use Babashka tasks, to see all available tasks run:
@@ -113,6 +116,19 @@ bb test --help
 
 We'll likely add finer grained test selection to satisfy developer needs.
 For now, temporarily tweak `./script/test.clj` if you need to.
+
+==== Testing User Guide Code Blocks
+
+There are many code examples in the user guide.
+In an attempt to ensure they are in working order, we run a selection of them through https://github.com/lread/test-doc-blocks[test-doc-blocks].
+
+[source,shell]
+----
+bb test-doc
+----
+
+If you are updating the user guide, it preferable if your code block can be run through test-doc-blocks.
+But if this is impractal, you can also have test-doc-blocks skip a code block.
 
 ==== Testing within Docker
 

--- a/doc/user-guide-sample-frame1.html
+++ b/doc/user-guide-sample-frame1.html
@@ -1,0 +1,2 @@
+<p id="in-frame1">In frame1 paragraph<p>
+<iframe id="frame2" src="user-guide-sample-frame2.html">

--- a/doc/user-guide-sample-frame2.html
+++ b/doc/user-guide-sample-frame2.html
@@ -1,0 +1,1 @@
+<p id="in-frame2">In frame2 paragraph<p>

--- a/doc/user-guide-sample.html
+++ b/doc/user-guide-sample.html
@@ -1,0 +1,171 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Etaoin User Guide Sample Page</title>
+  <style>
+    label,input,textarea {
+      display: block;
+      margin-bottom: 0.3em;
+    }
+    form.formy {
+      border: 1px solid black;
+      padding: 1em;
+      border-radius: 3px;
+    }
+  </style>
+  <script>
+    var submit_count = 0;
+    function formSubmitted() {
+      submit_count += 1;
+      document.getElementById("submit-count").innerHTML = submit_count;
+      const formData = new FormData(document.getElementById("sample-form"));
+      document.getElementById("submitted").innerHTML = JSON.stringify(Object.fromEntries(formData));
+      document.getElementById("sample-form").reset();
+    }
+
+    function linkClicked(obj) {
+      console.log(obj.textContent);
+      console.log(obj.innerText);
+      document.getElementById('clicked').innerHTML = obj.textContent || obj.innerText;
+    }
+    // trap all the clicks
+    document.addEventListener("click", function(event) {
+      var anchor = event.target.closest('a');
+      if(anchor !== null) {
+        event.preventDefault();
+        document.getElementById("clicked").innerHTML = anchor.textContent;
+      }
+    });
+
+  </script>
+</head>
+
+<body>
+  <h1>Etaoin User Guide - Sample Page</h1>
+  <p>A little sample page to illustrate some concepts described in the Etaoin user guide.</p>
+
+  <h2>Form</h2>
+  <div>Last submitted:
+    <pre id="submitted">{}</pre>
+  </div>
+
+  <form id="sample-form" method="GET" class="formy" onSubmit="formSubmitted(); return false;">
+    <!-- keep name and id different to avoid confusion in tutorial -->
+    <label>
+      username
+      <input id="uname" name="username" type="text" size="80" enabled=true autofocus/>
+    </label>
+    <label>
+      password
+      <input id="pw" name="password" type="password" size="80"/>
+    </label>
+    <label>
+      formal question
+      <input id="fq" name="formal-question" type="text" size="80"/>
+    </label>
+     <label>
+      textarea
+      <textarea id="text" name="remarks" rows=3 cols=80></textarea>
+    </label>
+    <label>
+      not enabled
+      <input id="ne" name="not-enabled" type="text" disabled="true" value="not enabled" size="80"/>
+    </label>
+    <button name="submit">Submit Form</button> (submits: <span id="submit-count">0</span>)
+  </form>
+
+  <h2>Links</h2>
+
+  <div>Last clicked:
+    <pre id="clicked">none</pre>
+  </div>
+
+  <div class="some-links">
+    <ul>
+      <li><a href="#">link 1</a></li>
+      <li><a href="#" class="active">link 2 (active)</a></li>
+      <li><a href="https://clojure.org">link 3 (clojure.org)</a></li>
+      <li style="display:none"><a id="cantseeme" href="#">link 4 (not visible)</a></li>
+    </ul>
+
+    <!-- an example used in user guide -->
+    <ul>
+        <li class="search-result">
+            <a href="a">a</a>
+        </li>
+        <li class="search-result">
+            <a href="b">b</a>
+        </li>
+        <li class="search-result">
+            <a href="c">c</a>
+        </li>
+    </ul>
+  </div>
+
+  <h2>Mish Mash</h2>
+  <div id="mishmash">
+    <span class="class1 class3">blarg in a span</span>
+    <div class="class2 class3 class4 class5">blarg in a div</div>
+    <p>blarg in a p</p>
+    <p>some other paragraph</p>
+  </div>
+
+  <h2>Query Tree Example</h2>
+  <div id="query-tree-example">
+    <div id="one">
+      <a href="#">a1</a>
+      <a href="#">a2</a>
+      <a href="#">a3</a>
+    </div>
+    <div id="two">
+      <a href="#">a4</a>
+      <a href="#">a5</a>
+      <a href="#">a6</a>
+    </div>
+    <div id="three">
+      <a href="#">a7</a>
+      <a href="#">a8</a>
+      <a href="#">a9</a>
+    </div>
+  </div>
+
+  <h2>Frames</h2>
+  <p id="in-main-page">In main page paragraph</p>
+  <iframe id="frame1" src="user-guide-sample-frame1.html"></iframe>
+
+  <h2>A longer section</h2>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed turpis tincidunt id aliquet risus feugiat in ante. Dui faucibus in ornare quam viverra. Turpis in eu mi bibendum neque egestas congue. Quam lacus suspendisse faucibus interdum posuere lorem ipsum. Nisl nunc mi ipsum faucibus vitae aliquet. Bibendum enim facilisis gravida neque convallis a cras semper. Vestibulum morbi blandit cursus risus at ultrices mi. Pellentesque diam volutpat commodo sed egestas. Id nibh tortor id aliquet lectus proin. Mauris nunc congue nisi vitae suscipit tellus. Eleifend donec pretium vulputate sapien nec sagittis aliquam malesuada bibendum. Pulvinar pellentesque habitant morbi tristique. At risus viverra adipiscing at in tellus integer feugiat scelerisque. Felis donec et odio pellentesque diam volutpat commodo sed. Neque sodales ut etiam sit amet nisl purus in. Nulla posuere sollicitudin aliquam ultrices sagittis orci a scelerisque. Lorem ipsum dolor sit amet consectetur adipiscing elit duis.
+
+Malesuada bibendum arcu vitae elementum. Nunc faucibus a pellentesque sit. Aliquet eget sit amet tellus cras. Pellentesque id nibh tortor id. Id nibh tortor id aliquet. Et molestie ac feugiat sed lectus vestibulum. Integer quis auctor elit sed vulputate mi sit amet. Metus aliquam eleifend mi in nulla posuere sollicitudin. Gravida in fermentum et sollicitudin ac orci phasellus egestas tellus. Sed felis eget velit aliquet sagittis id. Enim facilisis gravida neque convallis a cras semper auctor neque. Massa vitae tortor condimentum lacinia quis vel.
+
+Ut tortor pretium viverra suspendisse potenti nullam. Sed vulputate mi sit amet mauris commodo quis imperdiet massa. Mi in nulla posuere sollicitudin. Elit at imperdiet dui accumsan sit amet nulla. Urna nec tincidunt praesent semper feugiat nibh sed. Egestas purus viverra accumsan in. Aliquam sem fringilla ut morbi tincidunt augue. Commodo ullamcorper a lacus vestibulum sed arcu. In massa tempor nec feugiat nisl pretium fusce. Nibh mauris cursus mattis molestie a. Nunc consequat interdum varius sit. In est ante in nibh. Augue interdum velit euismod in pellentesque massa placerat. Tincidunt id aliquet risus feugiat in ante. Ac turpis egestas integer eget aliquet nibh praesent tristique magna. Quam adipiscing vitae proin sagittis nisl. Tellus id interdum velit laoreet id donec ultrices tincidunt.
+
+Molestie at elementum eu facilisis sed odio morbi. Mauris rhoncus aenean vel elit scelerisque mauris. Maecenas volutpat blandit aliquam etiam. Amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et. Urna et pharetra pharetra massa massa ultricies mi. Turpis egestas maecenas pharetra convallis posuere morbi leo urna molestie. Sed viverra tellus in hac habitasse. Gravida dictum fusce ut placerat orci. Tellus pellentesque eu tincidunt tortor aliquam nulla facilisi cras. Facilisis mauris sit amet massa vitae. In hendrerit gravida rutrum quisque.
+
+Sed vulputate odio ut enim blandit. Vulputate eu scelerisque felis imperdiet proin fermentum leo. Et malesuada fames ac turpis egestas integer eget. Ante in nibh mauris cursus mattis molestie a iaculis. Bibendum neque egestas congue quisque egestas diam in arcu. Sed adipiscing diam donec adipiscing tristique. Non consectetur a erat nam at lectus. Orci nulla pellentesque dignissim enim. Velit ut tortor pretium viverra suspendisse potenti nullam. Dolor morbi non arcu risus quis. Nulla facilisi etiam dignissim diam quis enim. Dolor morbi non arcu risus quis varius quam. Nunc sed blandit libero volutpat sed cras ornare. Libero volutpat sed cras ornare arcu. Scelerisque varius morbi enim nunc faucibus a. Euismod in pellentesque massa placerat. Scelerisque in dictum non consectetur.
+
+Neque gravida in fermentum et sollicitudin. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Risus feugiat in ante metus. Cursus in hac habitasse platea dictumst quisque sagittis. Dolor morbi non arcu risus quis varius quam. Habitasse platea dictumst vestibulum rhoncus est pellentesque elit. In hac habitasse platea dictumst. Porttitor eget dolor morbi non arcu. Nunc mattis enim ut tellus elementum sagittis vitae et. Accumsan sit amet nulla facilisi morbi tempus. Vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Feugiat pretium nibh ipsum consequat nisl vel pretium. Ut tristique et egestas quis ipsum suspendisse ultrices gravida.
+
+Aliquam sem fringilla ut morbi tincidunt augue interdum. Fermentum dui faucibus in ornare quam viverra orci. Donec ac odio tempor orci dapibus ultrices in. Volutpat commodo sed egestas egestas. Rhoncus est pellentesque elit ullamcorper dignissim. Aliquam eleifend mi in nulla posuere. Vitae elementum curabitur vitae nunc sed velit. Proin sed libero enim sed faucibus turpis. Id ornare arcu odio ut. Proin nibh nisl condimentum id venenatis a. Donec pretium vulputate sapien nec sagittis aliquam. Eu lobortis elementum nibh tellus molestie nunc non blandit massa. Sagittis purus sit amet volutpat consequat mauris nunc. Eget sit amet tellus cras adipiscing. Curabitur vitae nunc sed velit. Risus pretium quam vulputate dignissim suspendisse in est ante. Aenean pharetra magna ac placerat. Gravida arcu ac tortor dignissim convallis aenean et tortor. Nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut.
+
+Lectus quam id leo in vitae turpis massa. Etiam non quam lacus suspendisse. Gravida quis blandit turpis cursus in hac. Urna neque viverra justo nec ultrices dui. Nec feugiat in fermentum posuere. Elit at imperdiet dui accumsan. Quis eleifend quam adipiscing vitae proin. Integer quis auctor elit sed vulputate mi sit. Quam id leo in vitae turpis massa sed. Sagittis aliquam malesuada bibendum arcu vitae. Tincidunt eget nullam non nisi est sit amet facilisis magna. Nunc mi ipsum faucibus vitae aliquet.
+
+Feugiat scelerisque varius morbi enim nunc faucibus a pellentesque. Aenean sed adipiscing diam donec adipiscing tristique risus nec feugiat. Ultricies leo integer malesuada nunc vel risus commodo viverra. Urna neque viverra justo nec. Interdum velit euismod in pellentesque massa. Sed cras ornare arcu dui vivamus arcu felis. Risus quis varius quam quisque id. Cursus metus aliquam eleifend mi in. Eget felis eget nunc lobortis mattis aliquam faucibus purus in. Nunc scelerisque viverra mauris in aliquam sem fringilla ut. Morbi tincidunt ornare massa eget egestas purus. Nisl vel pretium lectus quam id leo.
+
+Enim praesent elementum facilisis leo. Placerat in egestas erat imperdiet sed euismod nisi. Volutpat sed cras ornare arcu dui vivamus arcu felis bibendum. Erat imperdiet sed euismod nisi. Mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et. Ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget. Pretium vulputate sapien nec sagittis aliquam. Arcu cursus vitae congue mauris rhoncus aenean vel elit scelerisque. Amet consectetur adipiscing elit duis. Arcu cursus vitae congue mauris. Volutpat maecenas volutpat blandit aliquam. At ultrices mi tempus imperdiet nulla malesuada pellentesque elit. Purus non enim praesent elementum facilisis leo vel fringilla est. Massa eget egestas purus viverra accumsan in nisl nisi.
+   <h2 id="last-section">Last section</h2>
+   <pre>
+   Avast, me proud beauty! Wanna know why my Roger is so Jolly? You’re drinking a Salty Dog? How’d you like to try the real thing? Drink up me hearties yoho …a pirates life for me Always be yourself, unless you can be a pirate. Then always be a pirate. STOP BLOWING HOLES IN MY SHIP!!! Work like a captain, play like a pirate. Arrrrrrrr Ahoy! lets trouble the water!
+
+   Come on up and see me urchins. Yes, that is a hornpipe in my pocket and I am happy to see you. Why is the rum gone? The average man will bristle if you say his father was dishonest, but he will brag a little if he discovers that his great- grandfather was a pirate.
+
+   You can always trust the untrustworthy because you can always trust that they will be untrustworthy. Its the trustworthy you can’t trust. Not all treasure is silver and gold Yarrrr! there be ony two ranks of leader amongst us pirates! Captain and if your really notorious then it’s Cap’n! Whats a pirate’s favorite fast food restaurant?  Arrrrbys! Arrrrrrrr
+
+   That’s some treasure chest you’ve got there. What are YOU doing here? Why is the rum gone? Drink up me hearties yoho …a pirates life for me Suddenly you’re like a pirate, you’re 65 years old and you’ve got an ear- ring. Work like a captain, play like a pirate. Well actualy piracy is a democracy with captains voted for by the crew. Arrrrrrrr
+
+   Have ya ever met a man with a real yardarm? You’re drinking a Salty Dog? How’d you like to try the real thing? So, tell me, why do they call ye, “Cap’n Feathersword?” You can always trust the untrustworthy because you can always trust that they will be untrustworthy. Its the trustworthy you can’t trust.
+   </pre>
+</body>
+</html>

--- a/env/dev/demo.clj
+++ b/env/dev/demo.clj
@@ -1,45 +1,44 @@
-#_{:clj-kondo/ignore [:use]}
-(use 'etaoin.api)
-(require '[etaoin.keys :as k])
+(require '[etaoin.api :as e]
+         '[etaoin.keys :as k])
 
-(def driver (chrome))
+(def driver (e/chrome))
 
-(go driver "https://en.wikipedia.org/")
+(e/go driver "https://en.wikipedia.org/")
 
 (def query-search {:tag :input :name :search})
 
-(wait-visible driver [{:id :simpleSearch} query-search])
+(e/wait-visible driver [{:id :simpleSearch} query-search])
 
 ;; search for something
-(fill driver query-search "Clojure programming language")
+(e/fill driver query-search "Clojure programming language")
 
-(clear driver query-search)
+(e/clear driver query-search)
 
-(fill-human driver query-search "Clojure programming language")
+(e/fill-human driver query-search "Clojure programming language")
 
-(fill driver query-search k/enter)
-(wait-visible driver {:class :mw-search-results})
+(e/fill driver query-search k/enter)
+(e/wait-visible driver {:class :mw-search-results})
 
-(scroll-down driver 100)
+(e/scroll-down driver 100)
 
 ;; I'm sure the first link is what I was looking for
-(click driver [{:class :mw-search-results}
-               {:class :mw-search-result-heading}
-               {:tag :a}])
+(e/click driver [{:class :mw-search-results}
+                 {:class :mw-search-result-heading}
+                 {:tag :a}])
 
-(wait-visible driver {:id :firstHeading})
+(e/wait-visible driver {:id :firstHeading})
 
-(get-url driver)
-(get-title driver)
+(e/get-url driver)
+(e/get-title driver)
 
-(has-text? driver "Clojure")
+(e/has-text? driver "Clojure")
 
 ;; navigate on history
-(back driver)
-(forward driver)
-(refresh driver)
+(e/back driver)
+(e/forward driver)
+(e/refresh driver)
 
-(screenshot driver "clojure.png")
+(e/screenshot driver "clojure.png")
 
 ;; stops Firefox and HTTP server
-(quit driver)
+(e/quit driver)

--- a/resources/clj-kondo.exports/etaoin/etaoin/config.edn
+++ b/resources/clj-kondo.exports/etaoin/etaoin/config.edn
@@ -1,4 +1,7 @@
-{:hooks
+{:linters
+ {:etaoin/with-x-action {:level :error}
+  :etaoin/binding-sym {:level :error}}
+ :hooks
  {:analyze-call
   {etaoin.api/with-chrome            etaoin.api/with-browser
    etaoin.api/with-firefox           etaoin.api/with-browser

--- a/resources/clj-kondo.exports/etaoin/etaoin/etaoin/api.clj_kondo
+++ b/resources/clj-kondo.exports/etaoin/etaoin/etaoin/api.clj_kondo
@@ -7,10 +7,13 @@
         binding-sym (nth macro-args bound-arg-ndx nil)]
     (if-not (h/symbol-node? binding-sym)
       ;; could use clj-kondo findings, but I think this is good for now
-      (throw (ex-info (format "Expected binding symbol as %s arg"
-                              ;; use words instead of numbers to avoid ambiguity
-                              (case 1 "second"
-                                    2 "third")) {}))
+      (api/reg-finding! (assoc (if binding-sym
+                                 (meta binding-sym)
+                                 (meta node))
+                               :message (format "Expected binding symbol as %s arg"
+                                                ;; use words instead of numbers to avoid ambiguity
+                                                (case bound-arg-ndx 1 "second" 2 "third"))
+                               :type :etaoin/binding-sym))
       (let [leading-args (take bound-arg-ndx macro-args)
             body (drop (inc bound-arg-ndx) macro-args)]
         {:node (api/list-node
@@ -23,16 +26,35 @@
                  (api/vector-node leading-args)
                  body))}))))
 
-(defn- with-x-down [node]
+(defn- with-x-down
+  "This is somewhat of a maybe an odd duck.
+  I think it is assumed to be used within a threading macro.
+  And itself employs a threadfirst macro.
+  So each body form need to have an action (dummy or not) threaded into it."
+  [node]
   (let [macro-args (rest (:children node))
-        [leading-args body] (split-at 2 macro-args)]
+        [input x & body] macro-args
+        dummy-action (api/map-node [])]
     {:node (api/list-node
-            (list*
-             (api/token-node 'do)
-               ;; dump the body
-             (api/list-node (list* body))
-               ;; reference the other args so that they are not linted as unused (if they happen to be symbols)
-             (api/vector-node leading-args)))}))
+            (apply list*
+                   (api/token-node 'do)
+                   ;; reference x and input just in case they contain something lint-relevant
+                   x input
+                   ;; dump the body, threading a dummy action in as first arg
+                   (map (fn [body-form]
+                          (cond
+                            ;; not certain this is absolutely what we want, but maybe close enough
+                            (h/symbol-node? body-form) (api/list-node (list* body-form dummy-action))
+                            (api/list-node? body-form) (let [children (:children body-form)]
+                                                         (assoc body-form :children (apply list*
+                                                                                           (first children)
+                                                                                           dummy-action
+                                                                                           (rest children))))
+                            :else
+                            (api/reg-finding! (assoc (meta body-form)
+                                                     :message "expected to be threaded through an action"
+                                                     :type :etaoin/with-x-action))))
+                        body)))}))
 
 (defn with-browser
   "Covers etaoin.api/with-chrome and all its variants
@@ -46,8 +68,12 @@
   [{:keys [node]}]
   (with-bound-arg node 2))
 
-(defn with-key-down [{:keys [node]}]
+(defn with-key-down
+  "[input key & body]"
+  [{:keys [node]}]
   (with-x-down node))
 
-(defn with-pointer-btn-down [{:keys [node]}]
+(defn with-pointer-btn-down
+  "[input button & body]"
+  [{:keys [node]}]
   (with-x-down node))

--- a/script/test.clj
+++ b/script/test.clj
@@ -41,7 +41,7 @@
             (test-def os "api" platform browser)))
          (sort-by :desc)
          (into [{:os "ubuntu" :cmd "bb lint" :desc "lint"}
-                {:os "ubuntu" :cmd "bb test-doc" :desc "test-doc"}]))))
+                {:os "macos" :cmd "bb test-doc" :desc "test-doc"}]))))
 
 (defn- launch-xvfb []
   (if (fs/which "Xvfb")

--- a/script/test.clj
+++ b/script/test.clj
@@ -40,7 +40,8 @@
                                (and (= "windows" os) (= "safari" browser))))]
             (test-def os "api" platform browser)))
          (sort-by :desc)
-         (into [{:os "ubuntu" :cmd "bb lint" :desc "lint"}]))))
+         (into [{:os "ubuntu" :cmd "bb lint" :desc "lint"}
+                {:os "ubuntu" :cmd "bb test-doc" :desc "test-doc"}]))))
 
 (defn- launch-xvfb []
   (if (fs/which "Xvfb")

--- a/script/test_doc.clj
+++ b/script/test_doc.clj
@@ -1,0 +1,23 @@
+#!/usr/bin/env bb
+
+(ns test-doc
+  (:require [helper.main :as main]
+            [helper.shell :as shell]
+            [lread.status-line :as status]))
+
+(defn generate-doc-tests []
+  (status/line :head "Generating tests for code blocks in documents")
+  (shell/clojure "-X:test-doc-blocks gen-tests"))
+
+(defn run-clj-doc-tests []
+  (status/line :head "Running code block tests under Clojure")
+  (shell/clojure "-M:test:test-docs" ))
+
+(defn -main [& args]
+  (when (main/doc-arg-opt args)
+    (generate-doc-tests)
+    (run-clj-doc-tests))
+  nil)
+
+(main/when-invoked-as-script
+ (apply -main *command-line-args*))

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -17,24 +17,24 @@
   Phantom.js (Ghostdriver) - obsolete and no longer tested
   https://github.com/detro/ghostdriver/blob/
   "
-  (:require [etaoin.impl.proc   :as proc]
-            [etaoin.impl.client :as client]
-            [etaoin.keys   :as keys]
-            [etaoin.query  :as query]
-            [etaoin.impl.util   :as util :refer [defmethods]]
-            [etaoin.impl.driver :as drv]
-            [etaoin.impl.xpath  :as xpath]
+  (:require
+   [babashka.fs :as fs]
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   [etaoin.impl.client :as client]
+   [etaoin.impl.driver :as drv]
+   [etaoin.impl.proc :as proc]
+   [etaoin.impl.util :as util :refer [defmethods]]
+   [etaoin.impl.xpath :as xpath]
+   [etaoin.keys :as k]
+   [etaoin.query :as query]
+   [slingshot.slingshot :refer [throw+ try+]])
 
-            [clojure.tools.logging     :as log]
-            [clojure.java.io           :as io]
-            [clojure.string            :as str]
-
-            [babashka.fs :as fs]
-            [cheshire.core       :refer [generate-stream]]
-            [slingshot.slingshot :refer [try+ throw+]])
-
-  (:import (java.util Date Base64)
-           java.text.SimpleDateFormat))
+  (:import
+   java.text.SimpleDateFormat
+   (java.util Base64 Date)))
 
 ;;
 ;; defaults
@@ -426,7 +426,7 @@
 ;;
 
 (defn go
-  "Open the URL the current window.
+  "Open the `url` in the current window.
 
   Example:
 
@@ -633,8 +633,6 @@
 (defn query-tree
   "Takes selectors and acts like a tree.
   Every next selector queries elements from the previous ones.
-  The fist selector relies on find-elements,
-  and the rest ones use find-elements-from
 
   {:tag :div} {:tag :a}
   means
@@ -642,7 +640,7 @@
   div1 -> [a1 a2 a3]
   div2 -> [a4 a5 a6]
   div3 -> [a7 a8 a9]
-  so the result will be [a1 ... a9]
+  so the result will be #{a1 ... a9}
   "
   [driver q & qs]
   (reduce (fn [elements q]
@@ -733,13 +731,13 @@
   [input & [button]]
   (add-action input {:type     "pointerDown"
                      :duration 0
-                     :button   (or button keys/mouse-left)}))
+                     :button   (or button k/mouse-left)}))
 
 (defn add-pointer-up
   [input & [button]]
   (add-action input {:type     "pointerUp"
                      :duration 0
-                     :button   (or button keys/mouse-left)}))
+                     :button   (or button k/mouse-left)}))
 
 (defn add-pointer-cancel
   [input]
@@ -1056,17 +1054,17 @@
 (defn left-click
   "A shortcut for `mouse-click` with the left button."
   [driver]
-  (mouse-click driver keys/mouse-left))
+  (mouse-click driver k/mouse-left))
 
 (defn right-click
   "A shortcut for `mouse-click` with the right button."
   [driver]
-  (mouse-click driver keys/mouse-right))
+  (mouse-click driver k/mouse-right))
 
 (defn middle-click
   "A shortcut for `mouse-click` with the middle button."
   [driver]
-  (mouse-click driver keys/mouse-middle))
+  (mouse-click driver k/mouse-middle))
 
 (defn mouse-click-on
   "
@@ -1084,7 +1082,7 @@
   that one, use `click` instead.
   "
   [driver q]
-  (mouse-click-on driver keys/mouse-left q))
+  (mouse-click-on driver k/mouse-left q))
 
 (defn right-click-on
   "
@@ -1092,7 +1090,7 @@
   and right click on it.
   "
   [driver q]
-  (mouse-click-on driver keys/mouse-right q))
+  (mouse-click-on driver k/mouse-right q))
 
 (defn middle-click-on
   "
@@ -1101,7 +1099,7 @@
   in a new tab.
   "
   [driver q]
-  (mouse-click-on driver keys/mouse-middle q))
+  (mouse-click-on driver k/mouse-middle q))
 
 
 ;;
@@ -1932,7 +1930,7 @@
 
 (defn- dump-logs
   [logs filename & [opt]]
-  (generate-stream
+  (json/generate-stream
     logs
     (io/writer filename)
     (merge {:pretty true} opt)))
@@ -2728,7 +2726,7 @@
       (when (< (rand) mistake-prob)
         (fill-el driver el (rand-char))
         (wait-key)
-        (fill-el driver el keys/backspace)
+        (fill-el driver el k/backspace)
         (wait-key))
       (fill-el driver el key)
       (wait-key))))
@@ -2835,7 +2833,7 @@
 (defn submit
   "Sends Enter button value to an element found with query."
   [driver q]
-  (fill driver q keys/enter))
+  (fill driver q k/enter))
 
 ;;
 ;; timeouts

--- a/src/etaoin/api2.clj
+++ b/src/etaoin/api2.clj
@@ -4,52 +4,49 @@
   without breaking them.
   "
   (:require
-   [etaoin.api :as api]))
-
+   [etaoin.api :as e]))
 
 (defmacro with-firefox
   [[bind & [options]] & body]
-  `(api/with-driver :firefox ~options ~bind
+  `(e/with-driver :firefox ~options ~bind
      ~@body))
-
 
 (defmacro with-chrome
   [[bind & [options]] & body]
-  `(api/with-driver :chrome ~options ~bind
+  `(e/with-driver :chrome ~options ~bind
      ~@body))
-
 
 (defmacro with-edge
   [[bind & [options]] & body]
-  `(api/with-driver :edge ~options ~bind
+  `(e/with-driver :edge ~options ~bind
      ~@body))
 
 
 (defmacro with-phantom
   [[bind & [options]] & body]
-  `(api/with-driver :phantom ~options ~bind
+  `(e/with-driver :phantom ~options ~bind
      ~@body))
 
 
 (defmacro with-safari
   [[bind & [options]] & body]
-  `(api/with-driver :safari ~options ~bind
+  `(e/with-driver :safari ~options ~bind
      ~@body))
 
 
 (defmacro with-chrome-headless
   [[bind & [options]] & body]
-  `(api/with-driver :chrome (assoc ~options :headless true) ~bind
+  `(e/with-driver :chrome (assoc ~options :headless true) ~bind
      ~@body))
 
 
 (defmacro with-firefox-headless
   [[bind & [options]] & body]
-  `(api/with-driver :firefox (assoc ~options :headless true) ~bind
+  `(e/with-driver :firefox (assoc ~options :headless true) ~bind
      ~@body))
 
 
 (defmacro with-edge-headless
   [[bind & [options]] & body]
-  `(api/with-driver :edge (assoc ~options :headless true) ~bind
+  `(e/with-driver :edge (assoc ~options :headless true) ~bind
      ~@body))

--- a/src/etaoin/dev.clj
+++ b/src/etaoin/dev.clj
@@ -3,10 +3,9 @@
   A namespace to cover Chrome's devtools features.
   "
   (:require
-   [clojure.string :as str]
    [cheshire.core :as json]
+   [clojure.string :as str]
    [etaoin.api :as api]))
-
 
 (defn try-parse-int
   [line]
@@ -14,11 +13,9 @@
        (catch Exception _e
          line)))
 
-
 (defn parse-json
   [string]
   (json/parse-string string true))
-
 
 (defn parse-method
   "
@@ -31,7 +28,6 @@
         (-> (str/lower-case method)
             (str/split #"\." 2))]
     (keyword topname lowname)))
-
 
 (defn process-log
   "
@@ -48,14 +44,12 @@
         (merge message)
         (assoc :_type _type))))
 
-
 (defn request?
   "
   True if a log entry belongs to a network domain.
   "
   [log]
   (some-> log :_type namespace (= "network")))
-
 
 (defn group-requests
   "
@@ -66,7 +60,6 @@
     (fn [log]
       (some-> log :message :params :requestId))
     logs))
-
 
 (defn log->request
   "

--- a/src/etaoin/ide/impl/api.clj
+++ b/src/etaoin/ide/impl/api.clj
@@ -8,17 +8,15 @@
    [clojure.string :as str]
    [clojure.test :refer [is]]
    [clojure.tools.logging :as log]
-   [etaoin.api :refer :all]
-   [etaoin.keys :as k]
-   [etaoin.impl.util :refer [defmethods]]))
-
+   [etaoin.api :as e]
+   [etaoin.impl.util :refer [defmethods]]
+   [etaoin.keys :as k]))
 
 (defn absolute-path?
   [path]
   (-> path
       str/lower-case
       (str/starts-with? "http")))
-
 
 (defn str->var
   "
@@ -28,7 +26,6 @@
   (if (str/starts-with? var "$")
     (keyword (subs var 2 (-> var count dec)))
     (keyword var)))
-
 
 (def special-keys
   {"ADD"          k/num-+
@@ -112,14 +109,12 @@
    "TAB"          k/tab
    "UP"           k/arrow-up})
 
-
 (defn fill-str-with-vars
   [string vars]
   (reduce (fn [acc [k v]]
             (let [pattern (re-pattern (format "\\$\\{%s\\}" (name k)))
                   value   (str v)]
               (str/replace acc pattern value))) string vars))
-
 
 (defn gen-send-key-input
   [input]
@@ -132,7 +127,6 @@
                     sp-key  (str (get special-keys key))]
                 (str/replace acc pattern sp-key))) input keys)))
 
-
 (defn gen-script-arguments
   [script vars]
   (reduce (fn [acc [k v]]
@@ -140,11 +134,9 @@
                   js-val  (str/replace (json/generate-string v) #"\"" "'")]
               (str/replace acc pattern js-val))) script vars))
 
-
 (defn gen-expession-script
   [script vars]
   (str "return " (gen-script-arguments script vars)))
-
 
 (defn make-query
   [target]
@@ -154,7 +146,6 @@
       "xpath"    {:xpath val}
       "linkText" {:tag :a :fn/has-text val}
       {:css (format "[%s]" target)})))
-
 
 (defn make-absolute-url
   [base-url target]
@@ -166,27 +157,22 @@
                    base-url)]
     (str base-url "/" target)))
 
-
 (defn make-assert-msg
   [command actual expected]
   (format "\nAssert command:\"%s\"\nExpected: %s\nActual: %s"
           (name command) expected actual))
-
 
 (defn dispatch-command
   #_{:clj-kondo/ignore [:unused-binding]}
   [driver command & [opt]]
   (some-> command :command))
 
-
 (defmulti run-command dispatch-command)
-
 
 (defmethod run-command
   :default
   [_driver command & _]
   (log/warnf "The \"%s\" command is not implemented" (:command command)))
-
 
 (defmethod run-command
   :assert
@@ -194,173 +180,150 @@
   (let [stored-value (str (get @vars (str->var target)))]
     (assert (= stored-value value) (make-assert-msg command stored-value value))))
 
-
 (defmethods run-command
   [:assertAlert :assertConfirmation :assertPrompt]
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [alert-msg (get-alert-text driver)]
-    (dismiss-alert driver)
+  (let [alert-msg (e/get-alert-text driver)]
+    (e/dismiss-alert driver)
     (assert (= alert-msg target) (make-assert-msg command alert-msg target))))
-
 
 (defmethod run-command
   :assertChecked
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (selected? driver (make-query target))]
+  (let [actual (e/selected? driver (make-query target))]
     (assert actual (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :assertNotChecked
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (selected? driver (make-query target))]
+  (let [actual (e/selected? driver (make-query target))]
     (assert (not actual) (make-assert-msg command actual false))))
-
 
 (defmethod run-command
   :assertEditable
   [driver {:keys [target command]} & [{_vars :vars}]]
   (let [q      (make-query target)
-        actual (and (enabled? driver (make-query target))
-                    (nil? (get-element-attr driver q :readonly)))]
+        actual (and (e/enabled? driver (make-query target))
+                    (nil? (e/get-element-attr driver q :readonly)))]
     (assert actual (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :assertNotEditable
   [driver {:keys [target command]} & [{_vars :vars}]]
   (let [q      (make-query target)
-        actual (and (enabled? driver (make-query target))
-                    (nil? (get-element-attr driver q :readonly)))]
+        actual (and (e/enabled? driver (make-query target))
+                    (nil? (e/get-element-attr driver q :readonly)))]
     (assert (not actual) (make-assert-msg command actual false))))
-
 
 (defmethod run-command
   :assertElementPresent
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (exists? driver (make-query target))]
+  (let [actual (e/exists? driver (make-query target))]
     (assert actual (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :assertElementNotPresent
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (absent? driver (make-query target))]
+  (let [actual (e/absent? driver (make-query target))]
     (assert actual (make-assert-msg command actual true))))
-
 
 (defmethods run-command
   [:assertValue :assertSelectedValue]
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-val (get-element-value driver (make-query target))]
+  (let [actual-val (e/get-element-value driver (make-query target))]
     (assert (= actual-val value)
             (make-assert-msg command actual-val value))))
-
 
 (defmethod run-command
   :assertNotSelectedValue
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-val (get-element-value driver (make-query target))]
+  (let [actual-val (e/get-element-value driver (make-query target))]
     (assert (not= actual-val value)
             (make-assert-msg command actual-val value))))
-
 
 (defmethod run-command
   :assertText
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-text (get-element-text driver (make-query target))]
+  (let [actual-text (e/get-element-text driver (make-query target))]
     (assert (= actual-text value)
             (make-assert-msg command actual-text value))))
-
 
 (defmethod run-command
   :assertNotText
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-text (get-element-text driver (make-query target))]
+  (let [actual-text (e/get-element-text driver (make-query target))]
     (assert (not= actual-text value)
             (make-assert-msg command actual-text value))))
-
 
 (defmethod run-command
   :assertSelectedLabel
   [driver {:keys [target value command]} & [{_vars :vars}]]
   (let [q            (make-query target)
-        selected-val (get-element-value driver q)
-        option-el    (query driver q {:value selected-val})
-        option-text  (get-element-text-el driver option-el)]
+        selected-val (e/get-element-value driver q)
+        option-el    (e/query driver q {:value selected-val})
+        option-text  (e/get-element-text-el driver option-el)]
     (assert (= option-text value)
             (make-assert-msg command option-text value))))
-
 
 (defmethod run-command
   :assertTitle
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [title (get-title driver)]
+  (let [title (e/get-title driver)]
     (assert (= title target) (make-assert-msg command title target))))
-
 
 (defmethod run-command
   :check
   [driver {:keys [target]} & [{_base-url :base-url}]]
   (let [q (make-query target)]
-    (when-not (selected? driver q)
-      (click driver q))))
-
+    (when-not (e/selected? driver q)
+      (e/click driver q))))
 
 (defmethod run-command
   :click
   [driver {:keys [target]} & [_opt]]
-  (click driver (make-query target)))
-
+  (e/click driver (make-query target)))
 
 (defmethod run-command
   :close
   [driver _ & _]
-  (close-window driver))
-
+  (e/close-window driver))
 
 (defmethod run-command
   :doubleClick
   [driver {:keys [target]} & [_opt]]
-  (double-click driver (make-query target)))
-
+  (e/double-click driver (make-query target)))
 
 (defmethod run-command
   :dragAndDropToObject
   [driver {:keys [target value]} & [_opt]]
-  (drag-and-drop driver
-                 (make-query target)
-                 (make-query value)))
-
+  (e/drag-and-drop driver
+                   (make-query target)
+                   (make-query value)))
 
 (defmethod run-command
   :echo
   [_driver {:keys [target]} {vars :vars}]
   (println (fill-str-with-vars target @vars)))
 
-
 (defmethod run-command
   :executeScript
   [driver {:keys [target value]} & [{vars :vars}]]
-  (let [result (js-execute driver (gen-script-arguments target @vars))]
+  (let [result (e/js-execute driver (gen-script-arguments target @vars))]
     (when-not (str/blank? value)
       (swap! vars assoc (str->var value) result))
     result))
-
 
 (defmethod run-command
   :open
   [driver {:keys [target]} & [{base-url :base-url}]]
   (if (absolute-path? target)
-    (go driver target)
-    (go driver (make-absolute-url base-url target))))
-
+    (e/go driver target)
+    (e/go driver (make-absolute-url base-url target))))
 
 (defmethod run-command
   :pause
   [_driver {:keys [target]} & [_opt]]
-  (wait (/ (Integer/parseInt target) 1000)))
-
+  (e/wait (/ (Integer/parseInt target) 1000)))
 
 ;; TODO refactor select fn, add select by-value
 (defmethods run-command
@@ -369,32 +332,30 @@
   (let [[type val] (str/split value #"=" 2)
         q          (make-query target)]
     (case type
-      "label" (select driver q val)
+      "label" (e/select driver q val)
 
       "index" (let [index (inc (Integer/parseInt val))] ;; the initial index in selenium is 0, in xpath and css selectors it is 1
-                (click-el driver (query driver q {:tag :option :index index})))
+                (e/click-el driver (e/query driver q {:tag :option :index index})))
 
-      (click-el driver (query driver q (make-query value))))))
-
+      (e/click-el driver (e/query driver q (make-query value))))))
 
 (defmethod run-command
   :selectFrame
   [driver {:keys [target]} & [_opt]]
   (cond
     (= target "relative=top")
-    (switch-frame-top driver)
+    (e/switch-frame-top driver)
 
     (= target "relative=parent")
-    (switch-frame-parent driver)
+    (e/switch-frame-parent driver)
 
     (str/starts-with? target "index=")
-    (switch-frame* driver (-> target
+    (e/switch-frame* driver (-> target
                               (str/split #"index=")
                               second
                               (Integer/parseInt)))
 
-    :else (switch-frame driver (make-query target))))
-
+    :else (e/switch-frame driver (make-query target))))
 
 (defmethod run-command
   :selectWindow
@@ -406,103 +367,90 @@
                           (str/split #"=")
                           second
                           str->var)]
-      (switch-window driver (get @vars handle-name)))
+      (e/switch-window driver (get @vars handle-name)))
 
     (str/starts-with? target "win_ser_")
     (let [index  (second (str/split target #"win_ser_"))
           index  (if (= index "local")
                    0
                    (Integer/parseInt index))
-          handle (get (get-window-handles driver) index)]
-      (switch-window driver handle))
+          handle (get (e/get-window-handles driver) index)]
+      (e/switch-window driver handle))
 
     :else (throw (ex-info "The `select window` can only be called using handles"
                           {:command command}))))
 
-
 (defmethod run-command
   :sendKeys
   [driver {:keys [target value]} & [{vars :vars}]]
-  (fill driver (make-query target) (-> (gen-send-key-input value)
+  (e/fill driver (make-query target) (-> (gen-send-key-input value)
                                        (fill-str-with-vars @vars))))
-
 
 (defmethod run-command
   :setWindowSize
   [driver {:keys [target]} & [_opt]]
   (let [[width height] (map #(Integer/parseInt %) (str/split target #"x"))]
-    (set-window-size driver width height)))
-
+    (e/set-window-size driver width height)))
 
 (defmethod run-command
   :store
   [_driver {:keys [target value]} & [{vars :vars}]]
   (swap! vars assoc (str->var value) target))
 
-
 (defmethod run-command
   :storeAttribute
   [driver {:keys [target value]} & [{vars :vars}]]
   (let [[locator attr-name] (str/split target "@" 2)
-        attr-val            (get-element-attr driver (make-query locator) attr-name)]
+        attr-val            (e/get-element-attr driver (make-query locator) attr-name)]
     (swap! vars assoc (str->var value) attr-val)))
-
 
 (defmethod run-command
   :storeText
   [driver {:keys [target value]} & [{vars :vars}]]
-  (let [text (get-element-text driver (make-query target))]
+  (let [text (e/get-element-text driver (make-query target))]
     (swap! vars assoc (str->var value) text)))
-
 
 (defmethod run-command
   :storeTitle
   [driver {:keys [value]} & [{vars :vars}]]
-  (let [title (get-title driver)]
+  (let [title (e/get-title driver)]
     (swap! vars assoc (str->var value) title)))
-
 
 (defmethod run-command
   :storeValue
   [driver {:keys [target value]} & [{vars :vars}]]
-  (let [val (get-element-value driver (make-query target))]
+  (let [val (e/get-element-value driver (make-query target))]
     (swap! vars assoc (str->var value) val)))
-
 
 (defmethod run-command
   :storeWindowHandle
   [driver {:keys [target]} & [{vars :vars}]]
-  (let [handle (get-window-handle driver)]
+  (let [handle (e/get-window-handle driver)]
     (swap! vars assoc (str->var target) handle)))
-
 
 (defmethod run-command
   :storeXpathCount
   [driver {:keys [target value]} & [{vars :vars}]]
-  (let [cnt (count (find-elements* driver locator-xpath target))]
+  (let [cnt (count (e/find-elements* driver e/locator-xpath target))]
     (swap! vars assoc (str->var value) cnt)))
-
 
 (defmethod run-command
   :submit
   [driver {:keys [target]} & [{_vars :vars}]]
-  (fill-el driver (query (make-query target) {:tag :input}) k/enter))
-
+  (e/fill-el driver (e/query (make-query target) {:tag :input}) k/enter))
 
 (defmethod run-command
   :type
   [driver {:keys [target value]} & [{vars :vars}]]
-  (fill driver (make-query target) (-> (gen-send-key-input value)
+  (e/fill driver (make-query target) (-> (gen-send-key-input value)
                                        (fill-str-with-vars @vars))))
-
 
 (defmethod run-command
   :unCheck
   [driver {:keys [target]} & [{_base-url :base-url}]]
   (let [q (make-query target)]
-    (when (selected? driver q)
-      (click driver q))))
-
+    (when (e/selected? driver q)
+      (e/click driver q))))
 
 (defmethod run-command
   :verify
@@ -510,165 +458,143 @@
   (let [stored-value (str (get @vars (str->var target)))]
     (is (= stored-value value) (make-assert-msg command stored-value value))))
 
-
 (defmethod run-command
   :verifyChecked
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (selected? driver (make-query target))]
+  (let [actual (e/selected? driver (make-query target))]
     (is (true? actual) (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :verifyNotChecked
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (selected? driver (make-query target))]
+  (let [actual (e/selected? driver (make-query target))]
     (is (false? actual) (make-assert-msg command actual false))))
-
 
 (defmethod run-command
   :verifyEditable
   [driver {:keys [target command]} & [{_vars :vars}]]
   (let [q      (make-query target)
-        actual (and (enabled? driver (make-query target))
-                    (nil? (get-element-attr driver q :readonly)))]
+        actual (and (e/enabled? driver (make-query target))
+                    (nil? (e/get-element-attr driver q :readonly)))]
     (is (true? actual) (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :verifyNotEditable
   [driver {:keys [target command]} & [{_vars :vars}]]
   (let [q      (make-query target)
-        actual (and (enabled? driver (make-query target))
-                    (nil? (get-element-attr driver q :readonly)))]
+        actual (and (e/enabled? driver (make-query target))
+                    (nil? (e/get-element-attr driver q :readonly)))]
     (is (false? actual) (make-assert-msg command actual false))))
-
 
 (defmethod run-command
   :verifyElementPresent
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (exists? driver (make-query target))]
+  (let [actual (e/exists? driver (make-query target))]
     (is (true? actual) (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   :verifyElementNotPresent
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [actual (absent? driver (make-query target))]
+  (let [actual (e/absent? driver (make-query target))]
     (is (true? actual) (make-assert-msg command actual true))))
-
 
 (defmethod run-command
   [:verifyValue :verifySelectedValue]
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-val (get-element-value driver (make-query target))]
+  (let [actual-val (e/get-element-value driver (make-query target))]
     (is (= actual-val value)
         (make-assert-msg command actual-val value))))
-
 
 (defmethod run-command
   :verifyNotSelectedValue
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-val (get-element-value driver (make-query target))]
+  (let [actual-val (e/get-element-value driver (make-query target))]
     (is (not= actual-val value)
         (make-assert-msg command actual-val value))))
-
 
 (defmethod run-command
   :verifyText
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-text (get-element-text driver (make-query target))]
+  (let [actual-text (e/get-element-text driver (make-query target))]
     (is (= actual-text value)
         (make-assert-msg command actual-text value))))
-
 
 (defmethod run-command
   :verifyNotText
   [driver {:keys [target value command]} & [{_vars :vars}]]
-  (let [actual-text (get-element-text driver (make-query target))]
+  (let [actual-text (e/get-element-text driver (make-query target))]
     (is (not= actual-text value)
         (make-assert-msg command actual-text value))))
-
 
 (defmethod run-command
   :verifySelectedLabel
   [driver {:keys [target value command]} & [{_vars :vars}]]
   (let [q            (make-query target)
-        selected-val (get-element-value driver q)
-        option-el    (query driver q {:value selected-val})
-        option-text  (get-element-text-el driver option-el)]
+        selected-val (e/get-element-value driver q)
+        option-el    (e/query driver q {:value selected-val})
+        option-text  (e/get-element-text-el driver option-el)]
     (is (= option-text value)
         (make-assert-msg command option-text value))))
-
 
 (defmethod run-command
   :verifyTitle
   [driver {:keys [target command]} & [{_vars :vars}]]
-  (let [title (get-title driver)]
+  (let [title (e/get-title driver)]
     (is (= title target) (make-assert-msg command title target))))
-
 
 (defmethod run-command
   :waitForElementEditable
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-enabled driver (make-query target)
-                {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-enabled driver (make-query target)
+                  {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForElementNotEditable
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-disabled driver (make-query target)
-                 {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-disabled driver (make-query target)
+                   {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForElementPresent
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-exists driver (make-query target)
-               {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-exists driver (make-query target)
+                 {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForElementNotPresent
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-absent driver (make-query target)
-               {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-absent driver (make-query target)
+                 {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForElementVisible
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-visible driver (make-query target)
-                {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-visible driver (make-query target)
+                  {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForElementNotVisible
   [driver {:keys [target value]} & [{_vars :vars}]]
-  (wait-invisible driver (make-query target)
-                  {:timeout (/ (Integer/parseInt value) 1000)}))
-
+  (e/wait-invisible driver (make-query target)
+                    {:timeout (/ (Integer/parseInt value) 1000)}))
 
 (defmethod run-command
   :waitForText
   [driver {:keys [target value]} & [{_vars :vars}]]
   (let [q (make-query target)]
-    (wait-visible driver q)
-    (wait-has-text driver q value)))
-
+    (e/wait-visible driver q)
+    (e/wait-has-text driver q value)))
 
 (defmethods run-command
   [:webdriverChooseCancelOnVisibleConfirmation
    :webdriverChooseCancelOnVisiblePrompt]
   [driver {:keys [_target _value]} & [{_vars :vars}]]
-  (dismiss-alert driver))
-
+  (e/dismiss-alert driver))
 
 (defmethods run-command
   [:webdriverChooseOkOnVisibleConfirmation]
   [driver {:keys [_target _value]} & [{_vars :vars}]]
-  (accept-alert driver))
-
+  (e/accept-alert driver))
 
 ;;
 ;; Control flow
@@ -677,25 +603,21 @@
 (defmethods run-command
   [:if :elseIf :repeatIf :while]
   [driver {:keys [target]} & [{vars :vars}]]
-  (js-execute driver (gen-expession-script target @vars)))
-
+  (e/js-execute driver (gen-expession-script target @vars)))
 
 (defmethods run-command
   [:do :end]
   [_ _ & _])
-
 
 (defmethod run-command
   :forEach
   [_driver {:keys [target value]} & [{vars :vars}]]
   [(str->var value) (get @vars (str->var target))])
 
-
 (defmethod run-command
   :times
   [_driver {:keys [target]} & [{_vars :vars}]]
   (Integer/parseInt target))
-
 
 (defn log-command-message
   [{:keys [command target value]}]
@@ -708,7 +630,6 @@
 
     "always"
     (str (format "Command: %s" (name command)))))
-
 
 (defn run-command-with-log
   "

--- a/src/etaoin/ide/main.clj
+++ b/src/etaoin/ide/main.clj
@@ -11,10 +11,10 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.tools.cli :refer [parse-opts]]
+   [clojure.tools.cli :as cli]
    [etaoin.api :as api]
    [etaoin.ide.flow :as flow]
-   [etaoin.impl.util :refer [exit]]))
+   [etaoin.impl.util :as util]))
 
 
 (def browsers-set
@@ -109,7 +109,7 @@ Options:")
   "
   [& args]
   (let [{:keys [errors summary options]}
-        (parse-opts args cli-options)
+        (cli/parse-opts args cli-options)
 
         {:keys [help file resource]}
         options]
@@ -117,22 +117,22 @@ Options:")
     (cond
 
       errors
-      (exit 1 (error-msg errors))
+      (util/exit 1 (error-msg errors))
 
       help
-      (exit 0 (usage summary))
+      (util/exit 0 (usage summary))
 
       file
       (let [ide-file (io/file file)]
         (when-not (and (.exists ide-file)
                        (not (.isDirectory ide-file)))
-          (exit 1 "The IDE file not found"))
+          (util/exit 1 "The IDE file not found"))
         (run-script ide-file options))
 
       resource
       (if-let [r (io/resource resource)]
         (run-script r options)
-        (exit 1 "Resource not found"))
+        (util/exit 1 "Resource not found"))
 
       :else
-      (exit 1 "Specify the path to the ide file: `--file` or `--resource`"))))
+      (util/exit 1 "Specify the path to the ide file: `--file` or `--resource`"))))

--- a/src/etaoin/impl/client.cljc
+++ b/src/etaoin/impl/client.cljc
@@ -1,10 +1,11 @@
 (ns ^:no-doc etaoin.impl.client
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            #?(:bb [clj-http.lite.client :as client]
-               :clj [clj-http.client :as client])
-            [cheshire.core :as json]
-            [slingshot.slingshot :refer [throw+]]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   #?(:bb [clj-http.lite.client :as client]
+      :clj [clj-http.client :as client])
+   [slingshot.slingshot :refer [throw+]]))
 
 ;;
 ;; defaults

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -33,10 +33,11 @@
   Selenium Python source code for Firefox
   https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/firefox/options.py
   "
-  (:require [etaoin.impl.util :refer [defmethods deep-merge]]
-            [babashka.fs :as fs]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]))
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [etaoin.impl.util :refer [deep-merge defmethods]]))
 
 (defn dispatch-driver
   [driver & _]

--- a/src/etaoin/impl/proc.clj
+++ b/src/etaoin/impl/proc.clj
@@ -1,6 +1,7 @@
 (ns ^:no-doc etaoin.impl.proc
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 (def windows? (str/starts-with? (System/getProperty "os.name") "Windows"))
 

--- a/src/etaoin/query.clj
+++ b/src/etaoin/query.clj
@@ -1,7 +1,8 @@
 (ns etaoin.query
   "A module to deal with querying elements."
-  (:require [etaoin.impl.util :as util]
-            [etaoin.impl.xpath :as xpath]))
+  (:require
+   [etaoin.impl.util :as util]
+   [etaoin.impl.xpath :as xpath]))
 
 ;; todo duplicates with api.clj
 (def locator-xpath "xpath")

--- a/test/etaoin/ide_test.clj
+++ b/test/etaoin/ide_test.clj
@@ -1,10 +1,11 @@
 (ns etaoin.ide-test
-  (:require [clojure.edn :as edn]
-            [etaoin.api :as api]
-            [etaoin.ide.flow :as ide]
-            [etaoin.test-report :as test-report]
-            [clojure.test :refer :all]
-            [clojure.java.io :as io]))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [etaoin.api :as e]
+   [etaoin.ide.flow :as ide]
+   [etaoin.test-report :as test-report]))
 
 (def ^:dynamic *driver*)
 (def ^:dynamic *base-url*)
@@ -25,8 +26,8 @@
   (let [base-url       (-> "html" io/resource str)
         test-file-path (-> "ide/test.side" io/resource str)]
     (doseq [type drivers]
-      (api/with-driver type {:args ["--no-sandbox"]} driver
-        (api/go driver base-url)
+      (e/with-driver type {:args ["--no-sandbox"]} driver
+        (e/go driver base-url)
         (binding [*driver*         driver
                   *base-url*       base-url
                   *test-file-path* test-file-path

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -1,30 +1,32 @@
 (ns etaoin.unit.proc-test
-  (:require [etaoin.api :refer :all]
-            [clojure.java.shell :refer [sh]]
-            [clojure.test :refer :all]
-            [etaoin.impl.proc :as proc]
-            [etaoin.test-report]
-            [clojure.pprint :as pprint]
-            [clojure.string :as str]))
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is]]
+   [etaoin.api :as e]
+   [etaoin.api2 :as e2]
+   [etaoin.impl.proc :as proc]
+   [etaoin.test-report]))
 
 (defn get-count-chromedriver-instances
   []
   (if proc/windows?
-    (let [instance-report (-> (sh "powershell" "-command" "(Get-Process chromedriver -ErrorAction SilentlyContinue).Path")
+    (let [instance-report (-> (shell/sh "powershell" "-command" "(Get-Process chromedriver -ErrorAction SilentlyContinue).Path")
                               :out
                               str/split-lines)]
       ;; more flakiness diagnosis
       (println "windows chromedriver instance report:" instance-report)
       (println "windows full list of running processes:")
       ;; use Get-CimInstance, because Get-Process, does not have commandline available
-      (pprint/pprint (-> (sh "powershell" "-command" "Get-CimInstance Win32_Process | select name, commandline")
+      (pprint/pprint (-> (shell/sh "powershell" "-command" "Get-CimInstance Win32_Process | select name, commandline")
                          :out
                          str/split-lines))
       (->> instance-report
            (remove #(str/includes? % "\\scoop\\shims\\")) ;; for the scoop users, exclude the shim process
            (filter #(str/includes? % "chromedriver"))
            count))
-    (->> (sh "sh" "-c" "ps aux")
+    (->> (shell/sh "sh" "-c" "ps aux")
          :out
          str/split-lines
          (filter #(str/includes? % "chromedriver"))
@@ -33,32 +35,32 @@
 (deftest test-process-forking-port-specified
   (let [port    9997
         process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (wait-running {:port port :host "localhost"})]
+        _       (e/wait-running {:port port :host "localhost"})]
     (is (= 1 (get-count-chromedriver-instances)))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"already in use"
-         (chrome {:port port})))
+         (e/chrome {:port port})))
     (proc/kill process)))
 
 (deftest test-process-forking-port-random
   (let [port    9998
         process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (wait-running {:port port :host "localhost"})]
-    (with-chrome {:args ["--no-sandbox"]} driver
-        ;; added to diagnose flakyness on windows on CI
+        _       (e/wait-running {:port port :host "localhost"})]
+    (e2/with-chrome [driver {:args ["--no-sandbox"]}]
+      ;; added to diagnose flakyness on windows on CI
       (println "automatically chosen port->" (:port driver))
-        ;; added to diagnose flakyness on windows on CI
-      (wait-running driver)
+      ;; added to diagnose flakyness on windows on CI
+      (e/wait-running driver)
       (is (= 2 (get-count-chromedriver-instances))))
     (proc/kill process)))
 
 (deftest test-process-forking-connect-existing
   (let [port    9999
         process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (wait-running {:port port :host "localhost"})
-        driver  (chrome {:host "localhost" :port port :args ["--no-sandbox"]})]
-    (wait-running driver)
+        _       (e/wait-running {:port port :host "localhost"})
+        driver  (e/chrome {:host "localhost" :port port :args ["--no-sandbox"]})]
+    (e/wait-running driver)
     (is (= 1 (get-count-chromedriver-instances)))
-    (quit driver)
+    (e/quit driver)
     (proc/kill process)))

--- a/test/etaoin/unit/xpath_test.clj
+++ b/test/etaoin/unit/xpath_test.clj
@@ -1,5 +1,5 @@
 (ns etaoin.unit.xpath-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [etaoin.test-report]
             [etaoin.impl.xpath :as xpath]))
 


### PR DESCRIPTION
New maintainer preference is to not use `:refer :all` in code and docs.
This is subjective, so apologies to those who prefer `:refer :all`.

This change should not affect behaviour of Etaoin.

I tried to be consistent in aliasing. For example `etaoin.api :as e`.
Also did a clojure-lsp clean-ns on each `ns`.

Deleted extra whitespace (newlines) when I noticed.

While sweeping the user guide:
- attempted to understand everything I read, and elaborated where I,
as a relative newcomer to Etaoin, was confused
- attempted a re-org to group related sections together
- reworded some sentences here and there
- add a section on creating the driver
- updated outdated text where I noticed it
- attempted to make most example code blocks something the user could
theoretically paste and run (and verified such myself)
- tweaked clj-kondo hooks for with-key-down and with-pointer-btn-down,
I discovered I hadn't quite got them correct enough.
At same time moved to registering lint findings instead of throwing.
- added in automated testing of many user guide code blocks via
test-doc-blocks via `bb test-doc`, added to CI