### PR TITLE
Switch with-exception from private to no-doc

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2091,7 +2091,7 @@
 ;; exceptions
 ;;
 
-(defmacro ^:private with-exception [catch fallback & body]
+(defmacro ^:no-doc with-exception [catch fallback & body]
   `(try+
      ~@body
      (catch ~catch ~(quote _)


### PR DESCRIPTION
This one is use from a macro, so it cannot be private.