### PR TITLE
Make opts optional for with-<driver> macros

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@ Minor Breaking Changes
 The symbol `num-.` is technically an invalid Clojure symbol and can confuse tooling. +
 A grep.app for `num-.` found Etaoin itself as the only user of this var.
 If your code uses `etaoin.keys/num-.`, you'll need to rename it to `etaoin.keys/num-dot`.
+
 * https://github.com/clj-commons/etaoin/issues/430[#430]: Declare the public API.
 We made what we think is a good guess at what the public Etaoin API is.
 The following namespaces are now considered internal and subject to change:
@@ -92,6 +93,9 @@ Other Changes
 * https://github.com/clj-commons/etaoin/issues/380[#380]: Etaoin is now Babashka compatible!
 * https://github.com/clj-commons/etaoin/issues/413[#413]: Etaoin now exports a clj-kondo config to help with the linting of its many handy macros
 * https://github.com/clj-commons/etaoin/pull/357[#357]: Add support for connecting to a remote WebDriver via `:webdriver-url` (thanks https://github.com/verma[@verma] for the PR and https://github.com/mjmeintjes[@mjmeintjes] for the example usage!)
+* https://github.com/clj-commons/etaoin/issues/453[#453]: The `etaoin.api/with-<browser>` macros no longer require `opts` to be specified.
+This makes the advantage of newer `etaoin.api2/with-<browser>` macros maybe less obvious.
+That said, for Etaoin users who have adopted and prefer the api2 versions, they are still there, but no longer documented in the user guide.
 * https://github.com/clj-commons/etaoin/issues/383[#383]: Drop testing for Safari on Windows, Apple no longer releases Safari for Windows
 * https://github.com/clj-commons/etaoin/issues/388[#388]: Drop testing for PhantomJS, development has long ago stopped for PhantomJS
 * https://github.com/clj-commons/etaoin/issues/387[#387]: No longer testing multiple key modifiers for a single webdriver send keys request

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -333,7 +333,6 @@ Unless otherwise directed, our examples throughout the rest of this guide will a
 [source,clojure]
 ----
 (require '[etaoin.api :as e]
-         '[etaoin.api2 :as e2]
          '[etaoin.keys :as k]
          '[clojure.java.io :as io])
 
@@ -378,9 +377,7 @@ To prevent that, we recommend the `with-<browser>` macros:
 
 [source,clojure]
 ----
-(require '[etaoin.api2 :as e2])
-
-(e2/with-firefox [driver]
+(e/with-firefox driver
   (doto driver
     (e/go "https://google.com")
     ;; ... your code here
@@ -425,16 +422,14 @@ Let's say we want to create a chrome headless driver:
 (e/quit driver)
 ----
 
-The v2 API has ergonomic `with-<browser>` functions that handle cleanup nicely:
+The `with-<browser>` functions handle cleanup nicely:
 
 [source,clojure]
 ----
-(require '[etaoin.api2 :as e2])
-
-(e2/with-chrome [driver {:headless true}]
+(e/with-chrome {:headless true} driver
   (e/go driver "https://clojure.org"))
 
-(e2/with-chrome-headless [driver]
+(e/with-chrome-headless driver
   (e/go driver "https://clojure.org"))
 ----
 
@@ -1324,7 +1319,7 @@ For example, the default `:normal` strategy:
 
 [source,clojure]
 ----
-(e2/with-chrome [driver]
+(e/with-chrome driver
   (e/go driver sample-page)
   ;; by default you'll hang on this line until the page loads
   ;; (do-something)
@@ -1335,7 +1330,7 @@ Load strategy option of `:none`:
 
 [source,clojure]
 ----
-(e2/with-chrome [driver {:load-strategy :none}]
+(e/with-chrome {:load-strategy :none} driver
   (e/go driver sample-page)
   ;; no pause, no waiting, acts immediately
   ;; (do-something)
@@ -1557,9 +1552,9 @@ To start a driver with devtools support enabled specify a `:dev` map.
 //{:test-doc-blocks/test-ns user-guide-devtools-test}
 [source,clojure]
 ----
-(require '[etaoin.api2 :as e2])
+(require '[etaoin.api :as e])
 
-(e2/with-chrome [driver {:dev {}}]
+(e/with-chrome driver {:dev {}}
   ;; do some stuff
 )
 ----
@@ -2170,12 +2165,12 @@ There are several shortcuts to run Chrome or Firefox in headless mode:
 
 ;; or
 
-(require '[etaoin.api2 :as e2])
+(require '[etaoin.api :as e])
 
-(e2/with-chrome-headless [driver]
+(e/with-chrome-headless driver
   (e/go driver "https://clojure.org"))
 
-(e2/with-firefox-headless [driver {:log-level :all}] ;; extra settings
+(e/with-firefox-headless {:log-level :all} driver ;; notice extra settings
   (e/go driver "https://clojure.org"))
 ----
 
@@ -2184,7 +2179,7 @@ There are also the `when-headless` and `when-not-headless` macros that conditona
 //{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
 ----
-(e2/with-chrome [driver]
+(e/with-chrome driver
   (e/when-not-headless driver
     ;;... some actions that might be not available in headless mode
     )
@@ -2229,7 +2224,8 @@ Set a custom `User-Agent` header with the `:user-agent` option when creating a d
 
 [source,clojure]
 ----
-(e2/with-firefox [driver {:user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"}]
+(e/with-firefox {:user-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"}
+                driver
   (e/get-user-agent driver))
 ;; => "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
 ----
@@ -2299,10 +2295,10 @@ Example:
 
 ;; Connect to a chrome instance on browserless.io via :webdriver-url
 ;; (replace YOUR-API-TOKEN with a valid browserless.io api token if you want to try this out)
-(e2/with-chrome [driver
-                 {:webdriver-url "https://chrome.browserless.io/webdriver"
-                  :capabilities {"browserless:token" "YOUR-API-TOKEN"
-                                 "chromeOptions" {"args" ["--no-sandbox"]}}}]
+(e/with-chrome {:webdriver-url "https://chrome.browserless.io/webdriver"
+                :capabilities {"browserless:token" "YOUR-API-TOKEN"
+                               "chromeOptions" {"args" ["--no-sandbox"]}}}
+               driver
   (e/go driver "https://en.wikipedia.org/")
   (e/wait-visible driver [{:id :simpleSearch} {:tag :input :name :search}])
   (e/fill driver {:tag :input :name :search} "Clojure programming language")
@@ -2414,13 +2410,12 @@ If for some reason you want to reuse a single driver instance for all tests:
 (ns project.test.integration
   "A module for integration tests"
   (:require [clojure.test :refer [deftest is use-fixtures]]
-            [etaoin.api :as e]
-            [etaoin.api :as e2]))
+            [etaoin.api :as e]))
 
 (def ^:dynamic *driver*)
 
 (defn fixture-browser [f]
-  (e2/with-chrome-headless [driver {:args ["--no-sandbox"]}]
+  (e/with-chrome-headless {:args ["--no-sandbox"]} driver
     (e/disconnect-driver driver)
     (binding [*driver* driver]
       (f))
@@ -2454,7 +2449,7 @@ For faster testing you can use this example:
 .....
 
 (defn fixture-browser [f]
-  (e2/with-chrome-headless [driver {:args ["--no-sandbox"]}]
+  (e/with-chrome-headless {:args ["--no-sandbox"]} driver
     (binding [*driver* driver]
       (f))))
 
@@ -2746,7 +2741,7 @@ Reproduction:: For example, `chromedriver` used to throw an error when calling `
 +
 [source,clojure]
 ----
-(e2/with-chrome [driver]
+(e/with-chrome driver
   (e/maximize driver))
 ;; an exception with "cannot get automation extension" was thrown
 ----
@@ -2851,7 +2846,7 @@ This bypasses OS security model.
 +
 [source,clojure]
 ----
-(e2/with-chrome [driver {:args ["--no-sandbox"]}]
+(e/with-chrome {:args ["--no-sandbox"]} driver
   (e/go driver "https://clojure.org"))
 ----
 

--- a/resources/clj-kondo.exports/etaoin/etaoin/config.edn
+++ b/resources/clj-kondo.exports/etaoin/etaoin/config.edn
@@ -1,11 +1,15 @@
 {:linters
  {:etaoin/with-x-action {:level :error}
-  :etaoin/binding-sym {:level :error}}
+  :etaoin/binding-sym {:level :error}
+  :etaoin/opts-map-type {:level :error}
+  :etaoin/opts-map-pos {:level :error}
+  :etaoin/empty-opts {:level :warning}}
  :hooks
  {:analyze-call
   {etaoin.api/with-chrome            etaoin.api/with-browser
-   etaoin.api/with-firefox           etaoin.api/with-browser
    etaoin.api/with-chrome-headless   etaoin.api/with-browser
+   etaoin.api/with-firefox           etaoin.api/with-browser
+   etaoin.api/with-firefox-headless  etaoin.api/with-browser
    etaoin.api/with-edge              etaoin.api/with-browser
    etaoin.api/with-edge-headless     etaoin.api/with-browser
    etaoin.api/with-phantom           etaoin.api/with-browser

--- a/resources/clj-kondo.exports/etaoin/etaoin/etaoin/api.clj_kondo
+++ b/resources/clj-kondo.exports/etaoin/etaoin/etaoin/api.clj_kondo
@@ -2,29 +2,63 @@
   (:require [clj-kondo.hooks-api :as api]
             [etaoin.hooks-util :as h]))
 
-(defn- with-bound-arg [node bound-arg-ndx]
+(defn- nil-node? [n]
+  (and (api/token-node? n) (nil? (api/sexpr n))))
+
+(defn- with-bound-arg [node arg-offset]
   (let [macro-args (rest (:children node))
-        binding-sym (nth macro-args bound-arg-ndx nil)]
-    (if-not (h/symbol-node? binding-sym)
-      ;; could use clj-kondo findings, but I think this is good for now
-      (api/reg-finding! (assoc (if binding-sym
-                                 (meta binding-sym)
-                                 (meta node))
-                               :message (format "Expected binding symbol as %s arg"
-                                                ;; use words instead of numbers to avoid ambiguity
-                                                (case bound-arg-ndx 1 "second" 2 "third"))
+        leading-args (take arg-offset macro-args)
+        interesting-args (drop arg-offset macro-args)
+        [opts binding-sym & body] (if (h/symbol-node? (second interesting-args))
+                                    interesting-args
+                                    (cons nil interesting-args))]
+    ;; if the user has specified nil or {} for options we can suggest that is not necessary
+    (when (and opts
+               (or (and (api/map-node? opts) (not (seq (:children opts))))
+                   (nil-node? opts)))
+      (api/reg-finding! (assoc (meta opts)
+                               :message "Empty or nil driver options can be omitted"
+                               :type :etaoin/empty-opts)))
+
+    (cond
+      (not (h/symbol-node? binding-sym))
+      ;; it makes more sense here to report on the incoming node position instead of what we expect to be the binding-sym
+      (api/reg-finding! (assoc (meta node)
+                               :message "Expected binding symbol for driver"
                                :type :etaoin/binding-sym))
-      (let [leading-args (take bound-arg-ndx macro-args)
-            body (drop (inc bound-arg-ndx) macro-args)]
-        {:node (api/list-node
-                (list*
+
+      ;; we don't want to explicitly expect a map because the map might come from
+      ;; an evalution, but we can do some checks
+      (and opts ;; we'll assume a list-node is a function call (eval)
+           (not (nil-node? opts)) ;; nil is actually old-v1 syntax acceptable
+           (not (api/list-node? opts)) ;; some fn call
+           (not (h/symbol-node? opts)) ;; from a binding maybe
+           ;; there are other eval node types... @(something) for example... maybe we'll add them in if folks ask
+           (not (api/map-node? opts)))
+      ;; we can report directly on the opts node, because at this point we know we expect
+      ;; this arg position to be an opts map
+      (api/reg-finding! (assoc (meta opts)
+                               :message "When specified, opts should be a map"
+                               :type :etaoin/opts-map-type))
+
+      ;; one last nicety, if the first form in body is a map, the user has accidentally swapped
+      ;; binding and opt args
+      (api/map-node? (first body))
+      (api/reg-finding! (assoc (meta (first body))
+                               :message "When specified, opts must appear before binding symbol"
+                               :type :etaoin/opts-map-pos))
+
+      :else
+      {:node (api/list-node
+               (list*
                  (api/token-node 'let)
-                   ;; simulate the effect, macro is creating a new thing (driver for example)
-                   ;; via binding it. I don't think the bound value matters for the linting process
+                 ;; simulate the effect, macro is creating a new thing (driver for example)
+                 ;; via binding it. I don't think the bound value matters for the linting process
                  (api/vector-node [binding-sym (api/map-node [])])
-                   ;; reference the other args so that they are not linted as unused
+                 ;; reference the other args so that they are not linted as unused
                  (api/vector-node leading-args)
-                 body))}))))
+                 opts ;; might be a binding, so ref it too
+                 body))})))
 
 (defn- with-x-down
   "This is somewhat of a maybe an odd duck.
@@ -58,15 +92,15 @@
 
 (defn with-browser
   "Covers etaoin.api/with-chrome and all its variants
-  [opt bind & body]"
+  [opt? bind & body]"
   [{:keys [node]}]
-  (with-bound-arg node 1))
+  (with-bound-arg node 0))
 
 (defn with-driver
   "Very similar to with-browser but bound arg is 1 deeper
-  [type opt bind & body]"
+  [type opt? bind & body]"
   [{:keys [node]}]
-  (with-bound-arg node 2))
+  (with-bound-arg node 1))
 
 (defn with-key-down
   "[input key & body]"

--- a/script/test.clj
+++ b/script/test.clj
@@ -141,7 +141,7 @@ Notes:
                                 (with-out-str (shell/clojure "-Spath" (str "-A" aliases)))
                                 "--main" "bb-test-runner"]))
               test-runner-args (case test-id
-                                 "api" ["--namespace" "etaoin.api-test"]
+                                 "api" ["--namespace-regex" "etaoin.api.*-test$"]
                                  "ide" ["--namespace" "etaoin.ide-test"]
                                  "unit" ["--namespace-regex" ".*unit.*-test$"]
                                  "all" [])

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -16,7 +16,6 @@
   - [[with-safari]] [[safari]] [[safari?]] [[when-safari]] [[when-not-safari]]
   - [[driver?]] [[running?]] [[headless?]] [[when-headless]] [[when-not-headless]]
   - [[disconnect-driver]] [[stop-driver]] [[quit]]
-  - see also [[etaoin.api2]]
 
   **WebDriver Lower Level Comms**
   -  [[execute]] [[with-http-error]]
@@ -2045,11 +2044,11 @@
   (implemented? driver get-logs*))
 
 (defn- dump-logs
-  [logs filename & [opt]]
+  [logs filename & [opts]]
   (json/generate-stream
     logs
     (io/writer filename)
-    (merge {:pretty true} opt)))
+    (merge {:pretty true} opts)))
 
 ;;
 ;; get/set hash
@@ -2454,19 +2453,19 @@
   Arguments:
 
   - `pred`: a zero-argument predicate to call
-  - `opt`: a map of optional parameters:
+  - `opts`: a map of optional parameters:
     - `:timeout` wait limit in seconds, [[*wait-timeout*]] by default;
     - `:interval` how long to wait between calls, [[*wait-interval*]] by default;
     - `:message` a message that becomes a part of exception when timeout is reached."
 
   ([pred]
    (wait-predicate pred {}))
-  ([pred opt]
-   (let [timeout   (get opt :timeout *wait-timeout*) ;; refactor this (call for java millisec)
-         time-rest (get opt :time-rest timeout)
-         interval  (get opt :interval *wait-interval*)
-         times     (get opt :times 0)
-         message   (get opt :message)]
+  ([pred opts]
+   (let [timeout   (get opts :timeout *wait-timeout*) ;; refactor this (call for java millisec)
+         time-rest (get opts :time-rest timeout)
+         interval  (get opts :interval *wait-interval*)
+         times     (get opts :times 0)
+         message   (get opts :message)]
      (when (< time-rest 0)
        (throw+ {:type      :etaoin/timeout
                 :message   message
@@ -2478,129 +2477,129 @@
                  (pred))
        (wait interval)
        (recur pred (assoc
-                     opt
+                     opts
                      :time-rest (- time-rest interval)
                      :times (inc times)))))))
 
 (defn wait-exists
   "Waits until `driver` finds element [[exists?]] via `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
+  - `opts`: see [[wait-predicate]] opts."
 
-  [driver q & [opt]]
+  [driver q & [opts]]
   (let [message (format "Wait until %s element exists" q)]
     (wait-predicate #(exists? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-absent
   "Waits until `driver` determines element is not found by `q` (is [[absent?]]).
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
+  - `opts`: see [[wait-predicate]] opts."
 
-  [driver q & [opt]]
+  [driver q & [opts]]
   (let [message (format "Wait until %s element is absent" q)]
     (wait-predicate #(absent? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-visible
   "Waits until `driver` determines element found by `q` is [[visible?]].
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q & [opts]]
   (let [message (format "Wait until %s element is visible" q)]
     (wait-predicate #(visible? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-invisible
   "Waits until `driver` determines element found by `q` is [[invisible?]].
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q & [opts]]
   (let [message (format "Wait until %s element is invisible" q)]
     (wait-predicate #(invisible? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-enabled
   "Waits until `driver` determines element found by `q` is [[enabled?]].
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q & [opts]]
   (let [message (format "Wait until %s element is enabled" q)]
     (wait-predicate #(enabled? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-disabled
   "Waits until `driver` determines element found by `q` is [[disabled?]].
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q & [opts]]
   (let [message (format "Wait until %s element is disabled" q)]
     (wait-predicate #(disabled? driver q)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-has-alert
   "Waits until `driver` finds page [[has-alert?]].
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver & [opts]]
   (let [message "Wait until element has alert"]
     (wait-predicate #(has-alert? driver)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-has-text
   "Waits until `driver` finds element via `q` with `text` anywhere inside it (including inner HTML).
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q text & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q text & [opts]]
   (let [message (format "Wait until %s element has text %s"
                         q text)]
     (wait-predicate #(has-text? driver q text)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-has-text-everywhere
   "Waits until `driver` finds `text` anywhere on the current page.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver text & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver text & [opts]]
   (let [q {:xpath "*"}]
-    (wait-has-text driver q text opt)))
+    (wait-has-text driver q text opts)))
 
 (defn wait-has-class
   "Waits until `driver` finds element via `q` [[has-class?]] `class`.
 
   See [[query]] for details on `q`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q class & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q class & [opts]]
   (let [message (format "Wait until %s element has class %s"
                         q class)]
     (wait-predicate #(has-class? driver q class)
-                    (merge {:message message} opt))))
+                    (merge {:message message} opts))))
 
 (defn wait-running
   "Waits until `driver` is reachable via its host and port via [[running?]].
 
   Throws if using `:webdriver-url`.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver & [opts]]
   (when (:webdriver-url driver)
     (throw (ex-info "Not supported for driver using :webdriver-url" {})))
   (log/debugf "Waiting until %s:%s is running"
               (:host driver) (:port driver))
-  (wait-predicate #(running? driver) opt))
+  (wait-predicate #(running? driver) opts))
 
 ;;
 ;; visible actions
@@ -2609,10 +2608,10 @@
 (defn click-visible
   "Waits until `driver` finds visible element via query `q` then clicks on it.
 
-  - `opt`: see [[wait-predicate]] opt."
-  [driver q & [opt]]
+  - `opts`: see [[wait-predicate]] opts."
+  [driver q & [opts]]
   (doto driver
-    (wait-visible q opt)
+    (wait-visible q opts)
     (click q)))
 
 ;;
@@ -2866,16 +2865,16 @@
                    :arg     q-text})))
 
 (defn fill-human-el
-  "Have `driver` fill element `el` with `text` as if it were a real human using `opt`.
+  "Have `driver` fill element `el` with `text` as if it were a real human using `opts`.
 
-  `opt`
+  `opts`
   - `:mistake-prob` probability of making a typo (0 to 1.0) (default: `0.1`)
   - `:pause-max` maximum amount of time in seconds to pause between keystrokes (can be fractional) (default: `0.2`)"
-  [driver el text opt]
+  [driver el text opts]
   {:pre [(some? el)]}
   (let [{:keys [mistake-prob pause-max]
          :or   {mistake-prob 0.1
-                pause-max    0.2}} opt
+                pause-max    0.2}} opts
 
         rand-char (fn [] (-> 26 rand-int (+ 97) char))
         wait-key  (fn [] (wait (min (rand) pause-max)))]
@@ -2891,39 +2890,38 @@
       (wait-key))))
 
 (defn fill-human
-  "Have `driver` fill element found by `q` with `text` as if it were a real human using `opt`.
+  "Have `driver` fill element found by `q` with `text` as if it were a real human using `opts`.
 
   See [[query]] for details on `q`.
 
-  `opt`
+  `opts`
   - `:mistake-prob` probability of making a typo (0 to 1.0) (default: `0.1`)
   - `:pause-max` maximum amount of time in seconds to pause between keystrokes (can be fractional) (default: `0.2`)"
   ([driver q text]  (fill-human driver q text {}))
-  ([driver q text opt]
-   (fill-human-el driver (query driver q) text opt)))
+  ([driver q text opts]
+   (fill-human-el driver (query driver q) text opts)))
 
 (defn fill-human-multi
-  "Have `driver` fill multiple elements as if it were a real human being via `q-text` using `opt`.
+  "Have `driver` fill multiple elements as if it were a real human being via `q-text` using `opts`.
 
   `q-text` can be:
   - a map of `{q1 \"text1\" q2 \"text2\" ...}`
   - a vector of `[q1 \"text1\" q2 \"text2\" ...]`
 
-
   See [[query]] for details on `q`s.
 
-  `opt`
+  `opts`
   - `:mistake-prob` probability of making a typo (0 to 1.0) (default: `0.1`)
   - `:pause-max` maximum amount of time in seconds to pause between keystrokes (can be fractional) (default: `0.2`)"
   ([driver q-text]  (fill-human-multi driver q-text {}))
-  ([driver q-text opt]
+  ([driver q-text opts]
    (cond
      (map? q-text)
      (doseq [[q text] q-text]
-       (fill-human driver q text opt))
+       (fill-human driver q text opts))
 
      (vector? q-text)
-     (recur driver (apply hash-map q-text) opt)
+     (recur driver (apply hash-map q-text) opts)
 
      :else (throw+ {:type    :etaoin/argument
                     :message "Wrong argument type"
@@ -3274,11 +3272,11 @@
   Tip: don't bother using `with-postmortem` in test fixtures.
   The standard `clojure.test`framework has its own way of handling exceptions,
   so wrapping a fixture with `(with-postmortem...)` would be in vain."
-  [driver opt & body]
+  [driver opts & body]
   `(try
      ~@body
      (catch Exception e#
-       (postmortem-handler ~driver ~opt)
+       (postmortem-handler ~driver ~opts)
        (throw e#))))
 
 ;;
@@ -3305,7 +3303,7 @@
   - `type` is a keyword determines what driver to use. The supported
   browsers are `:firefox`, `:chrome`, `:phantom` and `:safari`.
 
-  - `opt` is a map with additional options for a driver. The supported
+  - `opts` is a map with additional options for a driver. The supported
   options are:
 
   -- `:host` is a string with either IP or hostname. Use it if the
@@ -3360,7 +3358,7 @@
 
   - `driver` is a map created with `-create-driver` function.
 
-  - `opt` is an optional map with the following possible parameters:
+  - `opts` is an optional map with the following possible parameters:
 
   -- `:path-driver` is a string path to the driver's binary file. When
   not passed, it is taken from defaults.
@@ -3431,7 +3429,7 @@
 
   Arguments:
 
-  - `opt`: an map of the following optional parameters:
+  - `opts`: an map of the following optional parameters:
 
   -- `:capabilities` a map of desired capabilities your
   browser should support;
@@ -3534,21 +3532,21 @@
 
 (defn boot-driver
   "Launch and return a driver of `type` (e.g. `:chrome`, `:firefox` `:safari` `:edge` `:phantom`)
-  with `opt` options.
+  with `opts` options.
 
   - creates a driver
   - launches a WebDriver process (or connects to an existing running process if `:host` is specified)
   - creates a session for driver
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   ([type]
    (boot-driver type {}))
-  ([type {:keys [host webdriver-url] :as opt}]
+  ([type {:keys [host webdriver-url] :as opts}]
    (cond-> type
-     true                      (-create-driver opt)
+     true                      (-create-driver opts)
      (and (not host)
-          (not webdriver-url)) (-run-driver opt)
-     true                      (-connect-driver opt))))
+          (not webdriver-url)) (-run-driver opts)
+     true                      (-connect-driver opts))))
 
 (defn quit
   "Have `driver` close the current session, then, if Etaoin launched it, kill the WebDriver process."
@@ -3560,40 +3558,40 @@
         (when process
           (stop-driver driver))))))
 
-(def ^{:arglists '([] [opt])} firefox
+(def ^{:arglists '([] [opts])} firefox
   "Launch and return a Firefox driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   (partial boot-driver :firefox))
 
-(def ^{:arglists '([] [opt])} edge
+(def ^{:arglists '([] [opts])} edge
   "Launch and return an Edge driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   (partial boot-driver :edge))
 
-(def ^{:arglists '([] [opt])} chrome
+(def ^{:arglists '([] [opts])} chrome
   "Launch and return a Chrome driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   (partial boot-driver :chrome))
 
-(def ^{:arglists '([] [opt])} phantom
+(def ^{:arglists '([] [opts])} phantom
   "Launch and return a Phantom.js driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   (partial boot-driver :phantom))
 
-(def ^{:arglists '([] [opt])} safari
+(def ^{:arglists '([] [opts])} safari
   "Launch and return a Safari driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   (partial boot-driver :safari))
 
 (defn chrome-headless
   "Launch and return a headless Chrome driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   ([]
    (chrome-headless {}))
   ([opt]
@@ -3602,177 +3600,187 @@
 (defn firefox-headless
   "Launch and return a headless Firefox driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opts` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   ([]
    (firefox-headless {}))
-  ([opt]
-   (boot-driver :firefox (assoc opt :headless true))))
+  ([opts]
+   (boot-driver :firefox (assoc opts :headless true))))
 
 (defn edge-headless
   "Launch and return a headless Edge driver.
 
-  `opt` is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
+  `opt` map is optionally, see [Driver Options](/doc/01-user-guide.adoc#driver-options)."
   ([]
    (edge-headless {}))
-  ([opt]
-   (boot-driver :edge (assoc opt :headless true))))
+  ([opts]
+   (boot-driver :edge (assoc opts :headless true))))
 
 (defmacro with-driver
   "Executes `body` with a driver session of `type` (e.g. `:chrome`, `:firefox` `:safari` `:edge` `:phantom`)
-  with `opt` options, binding driver instance to `bind`.
+  with `opts` options, binding driver instance to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-driver :firefox {} driver
+  (with-driver :firefox driver
     (go driver \"https://clojure.org\"))
   ```"
-  [type opt bind & body]
-  `(client/with-pool {}
-     (let [~bind (boot-driver ~type ~opt)]
-       (try
-         ~@body
-         (finally
-           (quit ~bind))))))
+  {:arglists '([type opts? bind & body])}
+  [type & args]
+  (let [[opts bind & body] (if (symbol? (second args))
+                             args
+                             (cons nil args))]
+    `(client/with-pool {}
+       (let [~bind (boot-driver ~type ~opts)]
+         (try
+           ~@body
+           (finally
+             (quit ~bind)))))))
+
+(defmacro ^:no-doc with-headless-driver
+  {:arglists '([type opts? bind & body])}
+  [type & args]
+  (let [[opts bind & body] (if (symbol? (second args))
+                             args
+                             (cons nil args))]
+    `(let [opts# (assoc ~opts :headless true)]
+       (with-driver ~type opts# ~bind ~@body))))
 
 (defmacro with-firefox
   "Executes `body` with a Firefox driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-firefox {} driver
+  (with-firefox driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :firefox ~opt ~bind
-     ~@body))
+  {:arglists '([opts? bind & body] [bind & body])}
+  [& args]
+  `(with-driver :firefox ~@args))
 
 (defmacro with-chrome
   "Executes `body` with a Chrome driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-chrome {} driver
+  (with-chrome driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :chrome ~opt ~bind
-     ~@body))
-
-
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-driver :chrome ~@args))
 
 (defmacro with-edge
   "Executes `body` with an Edge driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-edge {} driver
+  (with-edge driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :edge ~opt ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-driver :edge ~@args))
 
 (defmacro with-phantom
   "Executes `body` with an Phantom.JS driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-phantom {} driver
+  (with-phantom driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :phantom ~opt ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-driver :phantom ~@args))
 
 (defmacro with-safari
   "Executes `body` with a Safari driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-safari {} driver
+  (with-safari driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :safari ~opt ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-driver :safari ~@args))
 
 (defmacro with-chrome-headless
   "Executes `body` with a headless Chrome driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-chrome-headless {} driver
+  (with-chrome-headless driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :chrome (assoc ~opt :headless true) ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-headless-driver :chrome ~@args))
 
 (defmacro with-firefox-headless
   "Executes `body` with a headless Firefox driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
   ```Clojure
-  (with-firefox-headless {} driver
+  (with-firefox-headless driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :firefox (assoc ~opt :headless true) ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-headless-driver :firefox ~@args))
 
 (defmacro with-edge-headless
   "Executes `body` with a headless Edge driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `opt` - can be `{}` or `nil`, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` map can be omitted, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
-
   ```Clojure
-  (with-edge-headless {} driver
+  (with-edge-headless driver
     (go driver \"https://clojure.org\"))
   ```"
-  [opt bind & body]
-  `(with-driver :edge (assoc ~opt :headless true) ~bind
-     ~@body))
+  {:arglists '([opts? bind & body])}
+  [& args]
+  `(with-headless-driver :edge ~@args))

--- a/src/etaoin/api2.clj
+++ b/src/etaoin/api2.clj
@@ -1,5 +1,5 @@
 (ns etaoin.api2
-  "Improved syntax for some [[etaoin.api]] calls"
+  "Alternate syntax for [[etaoin.api]] with-<driver> calls."
   (:require
    [etaoin.api :as e]))
 
@@ -8,7 +8,7 @@
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -16,8 +16,8 @@
   (with-firefox [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :firefox ~options ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :firefox ~opts ~bind
      ~@body))
 
 (defmacro with-chrome
@@ -25,7 +25,7 @@
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -33,8 +33,8 @@
   (with-chrome [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :chrome ~options ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :chrome ~opts ~bind
      ~@body))
 
 (defmacro with-edge
@@ -42,7 +42,7 @@
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -50,17 +50,16 @@
   (with-edge [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :edge ~options ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :edge ~opts ~bind
      ~@body))
-
 
 (defmacro with-phantom
   "Executes `body` with a Phantom.JS driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -68,17 +67,16 @@
   (with-phantom [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :phantom ~options ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :phantom ~opts ~bind
      ~@body))
-
 
 (defmacro with-safari
   "Executes `body` with a Safari driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -86,17 +84,16 @@
   (with-safari [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :safari ~options ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :safari ~opts ~bind
      ~@body))
-
 
 (defmacro with-chrome-headless
   "Executes `body` with a headless Chrome driver session bound to `bind`.
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -104,8 +101,8 @@
   (with-chrome-headless [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :chrome (assoc ~options :headless true) ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :chrome (assoc ~opts :headless true) ~bind
      ~@body))
 
 
@@ -114,7 +111,7 @@
 
   Driver is automatically launched and terminated (even if an exception occurs).
 
-  `options` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
+  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
 
   Example:
 
@@ -122,8 +119,8 @@
   (with-firefox-headless [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :firefox (assoc ~options :headless true) ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :firefox (assoc ~opts :headless true) ~bind
      ~@body))
 
 
@@ -140,6 +137,6 @@
   (with-edge-headless [driver]
     (go driver \"https://clojure.org\"))
   ```"
-  [[bind & [options]] & body]
-  `(e/with-driver :edge (assoc ~options :headless true) ~bind
+  [[bind & [opts]] & body]
+  `(e/with-driver :edge (assoc ~opts :headless true) ~bind
      ~@body))

--- a/test/etaoin/api_with_driver_test.clj
+++ b/test/etaoin/api_with_driver_test.clj
@@ -1,0 +1,240 @@
+(ns etaoin.api-with-driver-test
+  "Make sure all this sugar works and is linted by clj-kondo appropriately.
+
+  These tests are a bit wordy and code is repeated, but it all seems appropriate to me at this time.
+
+  These tests are separate etaoin.api-test because it uses a fixture as part of its strategy.
+  We do reuse the driver selection mechanism from etaoin.api-test tho."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [etaoin.api :as e]
+            [etaoin.api2 :as e2]
+            [etaoin.api-test :as api-test]
+            [etaoin.test-report]))
+
+(defn testing-driver? [type]
+  (some #{type} api-test/drivers))
+
+(def test-page (-> "html/test.html" io/resource str))
+(def my-agent "my agent")
+
+(deftest with-driver-tests
+  (when (testing-driver? :chrome)
+    (testing "chrome"
+      (println "testing chrome")
+      ;; with opts
+      (is (= my-agent
+             (e/with-driver :chrome {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-chrome {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-chrome-headless {:user-agent my-agent} driver
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))
+             (e2/with-chrome [driver {:user-agent my-agent}]
+               (e/get-user-agent driver))
+             (e2/with-chrome-headless [driver {:user-agent my-agent}]
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))))
+      ;; without opts
+      (is (= "Webdriver Test Document"
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-driver :chrome nil driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-driver :chrome {} driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-driver :chrome driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-chrome nil driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-chrome {} driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-chrome driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-chrome-headless nil driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-chrome-headless {} driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-chrome-headless driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             (e2/with-chrome [driver]
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e2/with-chrome-headless [driver]
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))))))
+
+  (when (testing-driver? :firefox)
+    (testing "firefox"
+      (println "testing firefox")
+      ;; with opts
+      (is (= my-agent
+             (e/with-driver :firefox {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-firefox {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-firefox-headless {:user-agent my-agent} driver
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))
+             (e2/with-firefox [driver {:user-agent my-agent}]
+               (e/get-user-agent driver))
+             (e2/with-firefox-headless [driver {:user-agent my-agent}]
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))))
+      ;; without opts
+      (is (= "Webdriver Test Document"
+             (e/with-driver :firefox driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-firefox nil driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-firefox {} driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-firefox driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+            #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+            (e/with-firefox-headless nil driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+            #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+            (e/with-firefox-headless {} driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-firefox-headless driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             (e2/with-firefox [driver]
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e2/with-firefox-headless [driver]
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))))))
+
+  (when (testing-driver? :edge)
+    (testing "edge"
+      (println "testing edge")
+      ;; with opts
+      (is (= my-agent
+             (e/with-driver :edge {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-edge {:user-agent my-agent} driver
+               (e/get-user-agent driver))
+             (e/with-edge-headless {:user-agent my-agent} driver
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))
+             (e2/with-edge [driver {:user-agent my-agent}]
+               (e/get-user-agent driver))
+             (e2/with-edge-headless [driver {:user-agent my-agent}]
+               (is (= true (e/headless? driver)))
+               (e/get-user-agent driver))))
+      ;; without opts
+      (is (= "Webdriver Test Document"
+             (e/with-driver :edge driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-edge nil driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-edge {} driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-edge driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-edge-headless nil driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-edge-headless {} driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-edge-headless driver
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             (e2/with-edge [driver]
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e2/with-edge-headless [driver]
+               (is (= true (e/headless? driver)))
+               (e/go driver test-page)
+               (e/get-title driver))))))
+
+  (when (testing-driver? :safari)
+    (testing "safari"
+      (println "testing safari")
+      ;; with opts
+      ;; safari driver does supports neither user agent nor headless
+      ;; not sure what other safari option is reflected in session... port?
+      (let [port 9995]
+        (e/with-driver :safari {:port port} driver
+          (is (= port (:port driver)))
+          (is (= true (e/running? driver))))
+        (e/with-safari {:port port} driver
+          (is (= port (:port driver)))
+          (is (= true (e/running? driver))) )
+        (e2/with-safari [driver {:port port}]
+          (is (= port (:port driver)))
+          (is (= true (e/running? driver)))))
+      ;; without opts
+      (is (= "Webdriver Test Document"
+             (e/with-driver :safari driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-safari nil driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             #_{:clj-kondo/ignore [:etaoin/empty-opts]}
+             (e/with-safari {} driver
+               (e/go driver test-page)
+               (e/get-title driver))
+             (e/with-safari driver
+               (e/go driver test-page)
+               (e/get-title driver))
+
+             (e2/with-safari [driver]
+               (e/go driver test-page)
+               (e/get-title driver)))))))

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -5,7 +5,6 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]
    [etaoin.api :as e]
-   [etaoin.api2 :as e2]
    [etaoin.impl.proc :as proc]
    [etaoin.test-report]))
 
@@ -47,7 +46,7 @@
   (let [port    9998
         process (proc/run ["chromedriver" (format "--port=%d" port)])
         _       (e/wait-running {:port port :host "localhost"})]
-    (e2/with-chrome [driver {:args ["--no-sandbox"]}]
+    (e/with-chrome {:args ["--no-sandbox"]} driver
       ;; added to diagnose flakyness on windows on CI
       (println "automatically chosen port->" (:port driver))
       ;; added to diagnose flakyness on windows on CI

--- a/test/etaoin/unit/unit_test.clj
+++ b/test/etaoin/unit/unit_test.clj
@@ -4,7 +4,6 @@
    [clojure.spec.alpha :as s]
    [clojure.test :refer [deftest is testing]]
    [etaoin.api :as e]
-   [etaoin.api2 :as e2]
    [etaoin.ide.flow :as ide]
    [etaoin.ide.impl.spec :as spec]
    [etaoin.impl.proc :as proc]
@@ -18,28 +17,28 @@
     proc/kill identity
     e/delete-session   identity]
     (testing "Session"
-      (e2/with-firefox [driver]
+      (e/with-firefox driver
         (is (= "session-key"
                (:session driver)))))
     (testing "No custom args"
-      (e2/with-firefox [driver {:port 1234}]
+      (e/with-firefox {:port 1234} driver
         (is (= ["geckodriver" "--port" 1234]
                (:args driver)))))
     (testing "Default `--marionette-port` is assigned when `:profile` is specified"
-      (e2/with-firefox [driver {:port 1234 :profile "/tmp/firefox-profile/1"}]
+      (e/with-firefox {:port 1234 :profile "/tmp/firefox-profile/1"} driver
         (is (= ["geckodriver" "--port" 1234 "--marionette-port" 2828]
                (:args driver)))))
     (testing "Custom `--marionette-port` is assigned when `:profile` is specified"
-      (e2/with-firefox [driver {:port        1234
-                                :profile     "/tmp/firefox-profile/1"
-                                :args-driver ["--marionette-port" 2821]}]
+      (e/with-firefox {:port 1234
+                       :profile     "/tmp/firefox-profile/1"
+                       :args-driver ["--marionette-port" 2821]} driver
         (is (= ["geckodriver" "--port" 1234 "--marionette-port" 2821]
                (:args driver)))))))
 
 (deftest test-chrome-profile
   (fs/with-temp-dir [chrome-dir {:prefix "chrome-dir"}]
     (let [profile-path (str (fs/file chrome-dir "chrome-profile"))]
-      (e2/with-chrome [driver {:profile profile-path :args ["--no-sandbox"]}]
+      (e/with-chrome {:profile profile-path :args ["--no-sandbox"]} driver
         (e/go driver "chrome://version")
         (is profile-path
             (e/get-element-text driver :profile_path))))))


### PR DESCRIPTION
This makes the advantage etaoin.api2 versions maybe less obvious,
but they remain for those who like them. But user guide won't explicitly
mention them with the thought that etaoin.api versions are now good
enough.

Updated clj-kondo macro hooks accordingly.

Added some with-driver tests to verify that all this macro sugar works.

Also: for consistency renamed arg names: opt and options -> opts.

Closes #453