### PR TITLE
Expose W3C WebDriver print to PDF feature

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -93,6 +93,7 @@ Other Changes
 * https://github.com/clj-commons/etaoin/issues/380[#380]: Etaoin is now Babashka compatible!
 * https://github.com/clj-commons/etaoin/issues/413[#413]: Etaoin now exports a clj-kondo config to help with the linting of its many handy macros
 * https://github.com/clj-commons/etaoin/pull/357[#357]: Add support for connecting to a remote WebDriver via `:webdriver-url` (thanks https://github.com/verma[@verma] for the PR and https://github.com/mjmeintjes[@mjmeintjes] for the example usage!)
+* https://github.com/clj-commons/etaoin/issues/355[#355]: Add support for W3C WebDriver print to PDF feature
 * https://github.com/clj-commons/etaoin/issues/453[#453]: The `etaoin.api/with-<browser>` macros no longer require `opts` to be specified.
 This makes the advantage of newer `etaoin.api2/with-<browser>` macros maybe less obvious.
 That said, for Etaoin users who have adopted and prefer the api2 versions, they are still there, but no longer documented in the user guide.

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1504,6 +1504,19 @@ this is equivalent to something along the lines of:
 (e/screenshot driver "target/etaoin-play/saved-screenshots/chrome-3.png")
 ----
 
+== Print Page to PDF
+
+Use `print-page` to print the current page to a PDF file:
+
+[source,clojure]
+----
+(e/with-firefox-headless driver
+  (e/go driver sample-page)
+  (e/print-page driver "target/etaoin-play/printed.pdf"))
+----
+
+See link:{url-doc}/CURRENT/api/etaoin.api/print-page[API docs] for details.
+
 == Peeking deeper
 
 Sometimes it is useful to go a little deeper.

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1515,7 +1515,7 @@ Use `print-page` to print the current page to a PDF file:
   (e/print-page driver "target/etaoin-play/printed.pdf"))
 ----
 
-See link:{url-doc}/CURRENT/api/etaoin.api/print-page[API docs] for details.
+See link:{url-doc}/CURRENT/api/etaoin.api#print-page[API docs] for details.
 
 == Peeking deeper
 


### PR DESCRIPTION
Exposed as `print-page` (avoids conflict with clojure.core/print).

Closes https://github.com/clj-commons/etaoin/issues/355