### PR TITLE
Driver defaults :path renamed to :path-driver

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,8 @@ The symbol `num-.` is technically an invalid Clojure symbol and can confuse tool
 A grep.app for `num-.` found Etaoin itself as the only user of this var.
 If your code uses `etaoin.keys/num-.`, you'll need to rename it to `etaoin.keys/num-dot`.
 
+* https://github.com/clj-commons/etaoin/issues/471[#471]: `etaoin.api/defaults` keyword `:path` renamed to `:path-driver` to match keyword used in driver options.
+
 * https://github.com/clj-commons/etaoin/issues/430[#430]: Declare the public API.
 We made what we think is a good guess at what the public Etaoin API is.
 The following namespaces are now considered internal and subject to change:

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1993,7 +1993,7 @@ If `:port` is found to  already in use when creating a new local WebDriver proce
 See also <<connecting-existing>>.
 
 Example: `:port 9997`
-a| Varies by vendor:
+a| Random port when lanching local WebDriver process, else varies by vendor:
 
 * chrome `9515`
 * firefox `4444`

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -95,8 +95,9 @@
 
 (defn set-capabilities
   [driver caps]
-  (update driver :capabilities deep-merge caps))
-
+  (if caps
+    (update driver :capabilities deep-merge caps)
+    driver))
 
 (defn set-load-strategy
   [driver strategy]

--- a/src/etaoin/impl/util.clj
+++ b/src/etaoin/impl/util.clj
@@ -82,3 +82,13 @@
         (.getPort u)
         (.getFile u)
         (.getRef u)))))
+
+(defn assoc-some
+  "Associates a key with a value in a map, if and only if the value is
+  not nil. From medley."
+  ([m k v]
+   (if (nil? v) m (assoc m k v)))
+  ([m k v & kvs]
+   (reduce (fn [m [k v]] (assoc-some m k v))
+           (assoc-some m k v)
+           (partition 2 kvs))))


### PR DESCRIPTION
Also:
- no longer add nil driver map values
- add `defaults-global` for defaults that apply to all driver types
- add some more tests around created driver map
- localized handling of most driver option defaults to one spot

Closes #471