### PR TITLE
Allow retry on failed WebDriver process launch

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -2032,6 +2032,12 @@ a| As you would expect, varies by vendor:
 Example: `:args-driver ["-b" "/path/to/firefox/binary"]`
 | <not set>
 
+| `:webdriver-failed-launch-retries`
+
+Introduced to compensate for mysterious but recoverable failed launches of safari driver.
+a| - safari `4` (for a total of 5 tries)
+- all other drivers `0`
+
 | `:path-browser` to *web browser* binary. +
 Typically used if your browser is not on the PATH.
 

--- a/src/etaoin/impl/util.clj
+++ b/src/etaoin/impl/util.clj
@@ -1,5 +1,9 @@
 (ns ^:no-doc etaoin.impl.util
-  (:import java.io.File))
+  (:import
+   [java.io File IOException]
+   [java.net InetSocketAddress ServerSocket Socket]))
+
+(set! *warn-on-reflection* true)
 
 (defn map-or-nil?
   [x]
@@ -37,20 +41,19 @@
    (error (apply format tpl args))))
 
 (defn get-free-port []
-  (let [socket (java.net.ServerSocket. 0)]
+  (let [socket (ServerSocket. 0)]
     (.close socket)
     (.getLocalPort socket)))
 
 (defn connectable?
-  "Checks whether it's possible to connect a given host/port pair."
+  "Returns `true` when it is possible to connect a given `host` over `port`."
   [host port]
-  (when-let [^java.net.Socket socket
-             (try
-               (java.net.Socket. ^String host ^int port)
-               (catch java.io.IOException _))]
-    (when (.isConnected socket)
-      (.close socket)
-      true)))
+  (with-open [socket (Socket.)]
+    (try
+      (.connect socket (InetSocketAddress. ^String host ^int port) 1000)
+      true
+      (catch IOException _e
+        false))))
 
 (defn exit
   [code template & args]


### PR DESCRIPTION
This allows us to compensate for mysterious, but recoverable,
safaridriver failed launches.

Default for safaridriver is set to 4 retries (total of 5 attempts).

Also host/port socket connectivity check updated to:
- include an explicit timeout of 1 second
- always close socket no matter what happens

Closes #468