### PR TITLE
Include driver process liveness in some exceptions 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -97,6 +97,7 @@ Other Changes
 * https://github.com/clj-commons/etaoin/pull/357[#357]: Add support for connecting to a remote WebDriver via `:webdriver-url` (thanks https://github.com/verma[@verma] for the PR and https://github.com/mjmeintjes[@mjmeintjes] for the example usage!)
 * https://github.com/clj-commons/etaoin/issues/355[#355]: Add support for W3C WebDriver print to PDF feature
 * https://github.com/clj-commons/etaoin/issues/466[#466]: WebDriver process output can now also be directed to console
+* https://github.com/clj-commons/etaoin/issues/468[#468]: Failed WebDriver process launch can now be automatically retried
 * https://github.com/clj-commons/etaoin/issues/453[#453]: The `etaoin.api/with-<browser>` macros no longer require `opts` to be specified.
 This makes the advantage of newer `etaoin.api2/with-<browser>` macros maybe less obvious.
 That said, for Etaoin users who have adopted and prefer the api2 versions, they are still there, but no longer documented in the user guide.
@@ -113,6 +114,7 @@ It also unconvered that our minimum Clojure version was 1.10, instead of the adv
 Fixed.
 * https://github.com/clj-commons/etaoin/issues/444[#444]: Visibility checks fixed for firefox and chrome (thanks https://github.com/daveyarwood[@daveyarwood]!)
 * https://github.com/clj-commons/etaoin/issues/455[#455]: Automatically create specified parent dirs for screenshots
+* https://github.com/clj-commons/etaoin/issues/469[#469]: Include WebDriver process liveness in http client exception
 * https://github.com/clj-commons/etaoin/issues/446[#446]: Bump Etaoin dependencies to current releases
 * Docs
 ** Reviewed and updated API docstrings

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -170,7 +170,8 @@
       (with-redefs [client/http-request (fn [_] (throw (ex-info "read timeout" {})))]
         ;; attempt connect, not launch
         (let [ex (try
-                   (e/with-chrome {:webdriver-url (format "http://localhost:%d" port) :args ["--no-sandbox"]} driver
+                   (e/with-chrome {:webdriver-url (format "http://localhost:%d" port)
+                                   :args ["--no-sandbox"]} _driver
                      (is false "should not get here"))
                    (catch Throwable ex
                      {:exception ex}))

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -5,17 +5,18 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]
    [etaoin.api :as e]
+   [etaoin.impl.client :as client]
    [etaoin.impl.proc :as proc]
    [etaoin.test-report]))
 
-(defn get-count-chromedriver-instances
-  []
+(defn get-count-driver-instances
+  [drivername]
   (if proc/windows?
-    (let [instance-report (-> (shell/sh "powershell" "-command" "(Get-Process chromedriver -ErrorAction SilentlyContinue).Path")
+    (let [instance-report (-> (shell/sh "powershell" "-command" (format "(Get-Process %s -ErrorAction SilentlyContinue).Path" drivername))
                               :out
                               str/split-lines)]
       ;; more flakiness diagnosis
-      (println "windows chromedriver instance report:" instance-report)
+      (println "windows" drivername "instance report:" instance-report)
       (println "windows full list of running processes:")
       ;; use Get-CimInstance, because Get-Process, does not have commandline available
       (pprint/pprint (-> (shell/sh "powershell" "-command" "Get-CimInstance Win32_Process | select name, commandline")
@@ -23,55 +24,158 @@
                          str/split-lines))
       (->> instance-report
            (remove #(str/includes? % "\\scoop\\shims\\")) ;; for the scoop users, exclude the shim process
-           (filter #(str/includes? % "chromedriver"))
+           (filter #(str/includes? % drivername))
            count))
     (->> (shell/sh "sh" "-c" "ps aux")
          :out
          str/split-lines
-         (filter #(str/includes? % "chromedriver"))
+         (filter #(str/includes? % drivername))
          count)))
 
-(deftest test-process-forking-port-specified
+(defn get-count-chromedriver-instances []
+  (get-count-driver-instances "chromedriver"))
+
+(defn get-count-firefoxdriver-instances []
+  (get-count-driver-instances "geckodriver"))
+
+(deftest test-process-forking-port-specified-is-in-use
   (let [port    9997
-        process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (e/wait-running {:port port :host "localhost"})]
-    (is (= 1 (get-count-chromedriver-instances)))
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"already in use"
-         (e/chrome {:port port})))
-    (proc/kill process)))
+        process (proc/run ["chromedriver" (format "--port=%d" port)])]
+    (try
+      (e/wait-running {:port port :host "localhost"})
+      (is (= 1 (get-count-chromedriver-instances)))
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"already in use"
+            (e/chrome {:port port})))
+      (finally
+        (proc/kill process)))))
 
-(deftest test-process-forking-port-random
+(deftest test-process-forking-port-not-specified-so-random-port-is-picked
   (let [port    9998
-        process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (e/wait-running {:port port :host "localhost"})]
-    (e/with-chrome {:args ["--no-sandbox"]} driver
-      ;; added to diagnose flakyness on windows on CI
-      (println "automatically chosen port->" (:port driver))
-      ;; added to diagnose flakyness on windows on CI
-      (e/wait-running driver)
-      (is (= 2 (get-count-chromedriver-instances))))
-    (proc/kill process)))
+        process (proc/run ["chromedriver" (format "--port=%d" port)])]
+    (try
+      (e/wait-running {:port port :host "localhost"})
+      (e/with-chrome {:args ["--no-sandbox"]} driver
+        ;; added to diagnose flakyness on windows on CI
+        (println "automatically chosen port->" (:port driver))
+        ;; added to diagnose flakyness on windows on CI
+        (e/wait-running driver)
+        (is (= 2 (get-count-chromedriver-instances))))
+      (finally
+        (proc/kill process)))))
 
-(deftest test-process-forking-connect-existing-host
+(deftest test-process-forking-connect-existing-webdriver-host
   (let [port    9999
-        process (proc/run ["chromedriver" (format "--port=%d" port)])
-        _       (e/wait-running {:port port :host "localhost"})
-        ;; should connect, not launch
-        driver  (e/chrome {:host "localhost" :port port :args ["--no-sandbox"]})]
-    (is (= 1 (get-count-chromedriver-instances)))
-    (e/quit driver)
-    (proc/kill process)))
+        process (proc/run ["chromedriver" (format "--port=%d" port)])]
+    (try
+      (e/wait-running {:port port :host "localhost"})
+      ;; should connect, not launch
+      (let [driver (e/chrome {:host "localhost" :port port :args ["--no-sandbox"]})]
+        (is (= 1 (get-count-chromedriver-instances)))
+        (e/quit driver))
+      (finally
+        (proc/kill process)))))
 
 (deftest test-process-forking-connect-existing-webdriver-url
   (let [port    9999
-        process (proc/run ["chromedriver" (format "--port=%d" port)])
-        ;; normally would not call wait-running for a remote service, we are simulating here and want
-        ;; to make sure the process we launched is up and running
-        _       (e/wait-running {:port port :host "localhost"})
-        ;; should connect, not launch
-        driver  (e/chrome {:webdriver-url (format "http://localhost:%d" port) :args ["--no-sandbox"]})]
-    (is (= 1 (get-count-chromedriver-instances)))
-    (e/quit driver)
-    (proc/kill process)))
+        process (proc/run ["chromedriver" (format "--port=%d" port)])]
+    (try
+      (e/wait-running {:port port :host "localhost"})
+      (let [;; should connect, not launch
+            driver  (e/chrome {:webdriver-url (format "http://localhost:%d" port) :args ["--no-sandbox"]})]
+
+
+        (is (= 1 (get-count-chromedriver-instances)))
+        (e/quit driver))
+      (finally
+        (proc/kill process)))))
+
+(deftest http-exception-on-create-proc-alive
+  ;; when etaoin tries to create a session we simulate a read timeout
+  (with-redefs [client/http-request (fn [_] (throw (ex-info "read timeout" {})))]
+    (let [ex (try
+               (e/with-firefox _driver
+                 (is false "should not reach here"))
+               (catch Throwable ex
+                 {:exception ex}))
+          exd (-> ex :exception ex-data)]
+      (is (= :etaoin/http-ex (:type exd)))
+      (is (= nil (-> exd :driver :process :exit)))
+      (is (= 0 (get-count-firefoxdriver-instances))))))
+
+(deftest http-error-on-create-proc-alive
+  ;; when etaoin tries to create a session return an http error
+  (with-redefs [client/http-request (fn [_] {:status 400})]
+    (let [ex (try
+               (e/with-firefox _driver
+                 (is false "should not reach here"))
+               (catch Throwable ex
+                 {:exception ex}))
+          exd (-> ex :exception ex-data)]
+      (is (= :etaoin/http-error (:type exd)))
+      (is (= 400 (:status exd)))
+      (is (= nil (-> exd :driver :process :exit)))
+      (is (= 0 (get-count-firefoxdriver-instances))))))
+
+(deftest http-exception-after-create-proc-now-dead
+  (let [orig-http-request client/http-request]
+    (with-redefs [client/http-request (fn [{:keys [method url] :as params}]
+                                        ;; allow create session through, fail on everything else
+                                        (if (and (= :post method) (str/ends-with? url "/session"))
+                                          (orig-http-request params)
+                                          (throw (ex-info "read timeout" {}))))]
+      (let [ex (try
+                 ;; go headless to avoid that dangling open web browser
+                 (e/with-firefox-headless driver
+                   (is (= 1 (get-count-firefoxdriver-instances)))
+                   (proc/kill (:process driver))
+                   ;; we'll now fail on this call
+                   (e/go driver "https://clojure.org"))
+                 (catch Throwable ex
+                   {:exception ex}))
+            exd (-> ex :exception ex-data)]
+        (is (= :etaoin/http-ex (:type exd)))
+        (is (= 143 (-> exd :driver :process :exit)))
+        (is (= 0 (get-count-firefoxdriver-instances)))))))
+
+(deftest http-error-after-create-proc-now-dead
+  ;; unlikely, we know we just talked to the driver because it returned an http error, but for completeness
+  (let [orig-http-request client/http-request]
+    (with-redefs [client/http-request (fn [{:keys [method url] :as params}]
+                                        ;; allow create session through, fail on everything else
+                                        (if (and (= :post method) (str/ends-with? url "/session"))
+                                          (orig-http-request params)
+                                          {:status 418}))]
+      (let [ex (try
+                 ;; go headless to avoid that dangling open web browser
+                 (e/with-firefox-headless driver
+                   (is (= 1 (get-count-firefoxdriver-instances)))
+                   (proc/kill (:process driver))
+                   ;; we'll now fail on this call
+                   (e/go driver "https://clojure.org"))
+                 (catch Throwable ex
+                   {:exception ex}))
+            exd (-> ex :exception ex-data)]
+        (is (= :etaoin/http-error (:type exd)))
+        (is (= 418 (:status exd)))
+        (is (= 143 (-> exd :driver :process :exit)))
+        (is (= 0 (get-count-firefoxdriver-instances)))))))
+
+(deftest test-cleanup-connect-existing-on-create-error
+  (let [port    9999
+        process (proc/run ["chromedriver" (format "--port=%d" port)])]
+    (try
+      (e/wait-running {:port port :host "localhost"})
+      (with-redefs [client/http-request (fn [_] (throw (ex-info "read timeout" {})))]
+        ;; attempt connect, not launch
+        (let [ex (try
+                   (e/with-chrome {:webdriver-url (format "http://localhost:%d" port) :args ["--no-sandbox"]} driver
+                     (is false "should not get here"))
+                   (catch Throwable ex
+                     {:exception ex}))
+              exd (-> ex :exception ex-data)]
+          (is (= :etaoin/http-ex (:type exd)))
+          (is (= 1 (get-count-chromedriver-instances)))))
+      (finally
+        (proc/kill process)))))

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -136,7 +136,8 @@
                    {:exception ex}))
             exd (-> ex :exception ex-data)]
         (is (= :etaoin/http-ex (:type exd)))
-        (is (= 143 (-> exd :driver :process :exit)))
+        ;; actual exit code varies by OS and is not important for this test
+        (is (integer? (-> exd :driver :process :exit)))
         (is (= 0 (get-count-firefoxdriver-instances)))))))
 
 (deftest http-error-after-create-proc-now-dead
@@ -159,7 +160,8 @@
             exd (-> ex :exception ex-data)]
         (is (= :etaoin/http-error (:type exd)))
         (is (= 418 (:status exd)))
-        (is (= 143 (-> exd :driver :process :exit)))
+        ;; actual exit code varies by OS and is not important for this test
+        (is (integer? (-> exd :driver :process :exit)))
         (is (= 0 (get-count-firefoxdriver-instances)))))))
 
 (deftest test-cleanup-connect-existing-on-create-error


### PR DESCRIPTION
When an http request, for example, times out one might wonder if the
WebDriver process is still running.

We now use slingshot throw+ as we do for http status errors. This throw+
still includes the :driver :process but checks if it is alive and
realizes its exit value in the thrown map if dead.

Also: if an exception occurs when booting a driver, any launched WebDriver
process is now cleaned up.

Also: reworked some proc tests to always attempt cleanup even when
exceptions occur.

Closes #469