### PR TITLE
Rollback our work on displayed? api function

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -112,7 +112,6 @@ That said, for Etaoin users who have adopted and prefer the api2 versions, they 
 This will allow for easier testing of unreleased versions of Etaoin via git deps.
 It also unconvered that our minimum Clojure version was 1.10, instead of the advertised v1.9.
 Fixed.
-* https://github.com/clj-commons/etaoin/issues/444[#444]: Visibility checks fixed for firefox and chrome (thanks https://github.com/daveyarwood[@daveyarwood]!)
 * https://github.com/clj-commons/etaoin/issues/455[#455]: Automatically create specified parent dirs for screenshots
 * https://github.com/clj-commons/etaoin/issues/469[#469]: Include WebDriver process liveness in http client exception
 * https://github.com/clj-commons/etaoin/issues/446[#446]: Bump Etaoin dependencies to current releases

--- a/env/test/resources/html/test.html
+++ b/env/test/resources/html/test.html
@@ -50,8 +50,7 @@
             <option value="rf">Russia</option>
             <option value="usa">United States</option>
             <option value="uk">United Kingdom</option>
-            <option id="option-visible" value="fr">France</option>
-            <option id="option-hidden" style="display: none" value="nowhere">Nowhere</option>
+            <option value="fr">France</option>
         </select>
         <label for="cars">Choose a car:</label>
         <select name="cars" id="cars" multiple>

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -76,10 +76,8 @@
 (deftest test-visible
   (doto *driver*
     (-> (e/visible? {:id :button-visible}) is)
-    (-> (e/visible? {:id :option-visible}) is)
     (-> (e/invisible? {:id :button-hidden}) is)
     (-> (e/invisible? {:id :div-hidden}) is)
-    (-> (e/invisible? {:id :option-hidden}) is)
     (-> (e/invisible? {:id :dunno-foo-bar}) is)))
 
 (deftest test-select


### PR DESCRIPTION
We have learned that displayed-ness is more complex than we had
originally imagined. It requires more research and maybe more hammock
time.

Effectively rolls back PR #445 for issue #444.