### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    environment: release
+
+    runs-on: ubuntu-latest
+    # I do not know of a way to restrict to the main branch so try to skip the whole job if
+    # user selected some other branch from GitHub Actions GUI
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup Git User so that we can later commit
+      uses: fregante/setup-git-user@v1
+
+    - name: Clojure deps cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.deps.clj
+          ~/.gitlibs
+        key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+        restore-keys: cljdeps-
+
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Install Clojure Tools
+      uses: DeLaGuardo/setup-clojure@9.3
+      with:
+        bb: 'latest'
+
+    - name: Tools Versions
+      run: |
+        echo "bb --version"
+        bb --version
+        echo "java -version"
+        java -version
+
+    - name: Download Clojure Dependencies
+      run: bb download-deps
+
+    - name: Release Prep (step 1 of 4)
+      run: bb ci-release prep
+
+    - name: Release Deploy (step 2 of 4)
+      env:
+        CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+        CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+      run: bb ci-release deploy-remote
+
+    - name: Release Commit (step 3 of 4)
+      run: bb ci-release commit
+
+    - name: Make GitHub Actions aware of target version tag
+      run: echo "::set-output name=tag::v$(bb clojure -T:build built-version)"
+      id: target-version
+
+    - name: Create GitHub release (step 4 of 4)
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.target-version.outputs.tag}}
+        release_name: ${{ steps.target-version.outputs.tag}}
+        commitish: main

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -132,6 +132,7 @@ Fixed.
 ** https://github.com/clj-commons/etaoin/issues/391[#391]: Identify browser name on failed ide tests
 ** https://github.com/clj-commons/etaoin/issues/390[#390]: Add internal clj-kondo config
 ** https://github.com/clj-commons/etaoin/issues/381[#381]: In addition to ubuntu, now also testing on macOS and Windows (using GitHub Actions https://github.com/clj-commons/etaoin/issues/392[#392] with parallelization https://github.com/clj-commons/etaoin/issues/420[#420])
+** https://github.com/clj-commons/etaoin/issues/422[#422]: Automate release workflow
 
 == v0.4.6
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,5 @@
 {:min-bb-version "0.8.2"
- :paths ["script"]
+ :paths ["script" "build"]
  :deps {doric/doric {:mvn/version "0.9.0"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}
@@ -52,4 +52,6 @@
                                (str (fs/cwd) ":/etaoin")
                                "-w" "/etaoin"
                                "etaoin:latest"
-                               *command-line-args*)}}}
+                               *command-line-args*)}
+  ci-release     {:doc "release tasks, use --help for args"
+                  :task ci-release/-main }}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,5 @@
 {:min-bb-version "0.8.2"
- :paths ["script" "build"]
+ :paths ["script"]
  :deps {doric/doric {:mvn/version "0.9.0"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}

--- a/build.clj
+++ b/build.clj
@@ -1,19 +1,23 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
-            [clojure.string :as string]))
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.tools.build.api :as b]
+            [deps-deploy.deps-deploy :as dd]))
 
-(defn- num-releases
-  "We'll assume num tags = num releases"
-  []
-  (-> (b/git-process {:git-args "tags"})
-      (string/split-lines)
-      count))
+(defn version-string []
+  (let [{:keys [major minor release qualifier]} (-> "version.edn"
+                                                    slurp
+                                                    edn/read-string)]
+    (format "%s.%s.%s%s"
+            major minor release (if qualifier
+                                  (str "-" qualifier)
+                                  ""))))
 
 (def lib 'etaoin/etaoin)
-(def version (format "1.0.%d" (inc (num-releases))))
+(def version (version-string)) ;; the expectations is some pre-processing has bumped the version when releasing
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
-(def jar-file (format "target/%s-%s.jar" (name lib) version))
+(def jar-file (format "target/%s.jar" (name lib)))
 (def built-jar-version-file "target/built-jar-version.txt")
 
 (defn clean [_]
@@ -29,11 +33,10 @@
   (let [version (if version-suffix
                   (format "%s-%s" version version-suffix)
                   version)]
-
     (b/write-pom {:class-dir class-dir
                   :lib lib
                   :version version
-                  :scm {:tag version}
+                  :scm {:tag (format "v%s" version)}
                   :basis basis
                   :src-dirs ["src"]})
     (b/copy-dir {:src-dirs ["src" "resources"]
@@ -42,6 +45,19 @@
             :jar-file jar-file})
     (spit built-jar-version-file version)
     (assoc opts :built-jar-version version)))
+
+(defn- built-version* []
+  (when (not (.exists (io/file built-jar-version-file)))
+    (throw (ex-info (str "Built jar version file not found: " built-jar-version-file) {})))
+  (slurp built-jar-version-file))
+
+(defn built-version
+  ;; NOTE: Used by release script and github workflow
+  "Spit out version of jar built (with no trailing newline).
+  A separate task because I don't know what build.tools might spit to stdout."
+  [_]
+  (print (built-version*))
+  (flush))
 
 (defn install [opts]
   (clean opts)
@@ -52,12 +68,9 @@
                 :basis basis
                 :jar-file jar-file})))
 
-(defn publish [opts]
-  (clean opts)
-  (jar opts)
-  ((requiring-resolve 'deps-deploy.deps-deploy/deploy)
-    (merge {:installer :remote
-                       :artifact jar-file
-                       :pom-file (b/pom-path {:lib lib :class-dir class-dir})}
-                    opts))
+(defn deploy [opts]
+  (dd/deploy
+   {:installer :remote
+    :artifact jar-file
+    :pom-file (b/pom-path {:lib lib :class-dir class-dir})})
   opts)

--- a/deps.edn
+++ b/deps.edn
@@ -44,6 +44,7 @@
 
   :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
                  slipset/deps-deploy {:mvn/version "0.2.0"}}
+          :extra-paths ["build"]
           :ns-default build}
 
   :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "1.9.874"}

--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,6 @@
 
   :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
                  slipset/deps-deploy {:mvn/version "0.2.0"}}
-          :extra-paths ["build"]
           :ns-default build}
 
   :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "1.9.874"}

--- a/doc/03-maintainer-guide.adoc
+++ b/doc/03-maintainer-guide.adoc
@@ -1,6 +1,66 @@
 = Maintainer Guide
 :toclevels: 5
 :toc:
+:url-release-action: https://github.com/clj-commons/etaoin/actions?query=workflow%3A%22Release%22 
 
 == Introduction
-Coming soon
+Notes for project maintainers.
+
+== Release Workflow
+
+The release workflow is handled by our link:{url-release-action}[Release] GitHub Action.
+
+. Fail fast if:
+.. Change log not ready
+. Bump `version.edn` for release version
+. Create thin jar using release version
+. Apply release version to the following docs:
+.. user guide for usage examples
+.. change log "unreleased" heading
+. Deploy jar to clojars
+. Commit changes made to docs and `version.edn`
+. Create and push a release tag back to the project repo
+. Inform cljdoc of the new release
+
+[IMPORTANT]
+====
+At this time, the release workflow does not run tests.
+The assumption is that you've waited for the last CI test run to complete and are happy with the results.
+====
+
+== Updating the Version
+
+Release num is bumped automatically by release workflow.
+
+Edit `major` and `minor` by editing `version.edn` in the project root.
+
+== Local Verification
+
+To check if things seeem ready:
+
+[source,shell]
+----
+bb ci-release validate
+----
+
+If you want to run everything up to, but not including, commit and push:
+
+[source,shell]
+----
+bb ci-release prep
+----
+
+IMPORTANT: You will NOT want to check in changes made by `prep`.
+
+== Special Setup
+
+GitHub has been configured with necessary secrets for GitHub Actions to deploy to clojars.
+
+== Invoking
+
+As a maintainer you should have sufficient privileges to see a "Run Workflow" dropdown button on the link:{url-release-action}[Release] action page.
+The dropdown will prompt for a branch.
+I did not see a way to disable this prompt, simply leave it at "master" and run the workflow.
+
+TIP: Don't forget to pull after a release to get the changes made by the release workflow.
+

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -3,5 +3,5 @@
   ["Changelog" {:file "CHANGELOG.adoc"}]
   ["User Guide" {:file "doc/01-user-guide.adoc"}]
   ["Developer Guide" {:file "doc/02-developer-guide.adoc"}]
-  ["Maintainer Guide" {:file "doc/03-maintainer-guide.doc"}]]
+  ["Maintainer Guide" {:file "doc/03-maintainer-guide.adoc"}]]
  :cljdoc/languages ["clj"]}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -2,5 +2,6 @@
  [["Readme" {:file "README.adoc"}]
   ["Changelog" {:file "CHANGELOG.adoc"}]
   ["User Guide" {:file "doc/01-user-guide.adoc"}]
-  ["Developer Guide" {:file "doc/02-developer-guide.adoc"}]]
+  ["Developer Guide" {:file "doc/02-developer-guide.adoc"}]
+  ["Maintainer Guide" {:file "doc/03-maintainer-guide.doc"}]]
  :cljdoc/languages ["clj"]}

--- a/script/ci_release.clj
+++ b/script/ci_release.clj
@@ -1,0 +1,206 @@
+#!/usr/bin/env bb
+
+;;
+;; This script is ultimately run from GitHub Actions
+;;
+
+(ns ci-release
+  (:require [babashka.fs :as fs]
+            [clojure.string :as string]
+            [helper.main :as main]
+            [helper.shell :as shell]
+            [lread.status-line :as status]
+            [rewrite-clj.zip :as z]))
+
+(defn clean! []
+  (doseq [dir ["target" ".cpcache"]]
+    (when (fs/exists? dir)
+      (fs/delete-tree dir))))
+
+(defn- last-release-tag []
+  (->>  (shell/command {:out :string}
+                       "git tag --sort=-creatordate")
+        :out
+        string/split-lines
+        ;; support old and new tag version scheme
+        ;; old had no prefix: 0.4.6
+        ;; new prefixes with v: v1.0.37
+        (filter #(re-matches #"v?\d+\..*" %))
+        first))
+
+(defn- update-file! [fname match-replacements]
+  (let [old-content (slurp fname)
+        new-content (reduce (fn [in [desc match replacement]]
+                              (let [out (string/replace-first in match replacement)]
+                                (if (= in out)
+                                  (status/die 1 "Expected to %s in %s" desc fname)
+                                  out)))
+                            old-content
+                            match-replacements)]
+    (spit fname new-content)))
+
+(defn- update-user-guide! [version]
+  (status/line :head (str "Updating project version in user guide to " version))
+  (update-file! "doc/01-user-guide.adoc"
+                [["update :lib-version: adoc attribute"
+                  #"(?m)^(:lib-version: )(.*)$"
+                  (str "$1"version)]]))
+
+(defn- validate-changelog
+  "Certainly not fool proof, but should help for common mistakes"
+  []
+  (status/line :head "Validating change log")
+  (let [content (slurp "CHANGELOG.adoc")
+        valid-attrs ["[minor breaking]" "[breaking]"]
+        [_ suffix desc :as match] (re-find #"(?ims)^== Unreleased ?(.*?)$(.*?)(== v\d|\z)" content)]
+    (cond
+      (not match)
+      (status/die 1 "Unreleased section not found.")
+
+      (and suffix
+           (not (string/blank? suffix))
+           (not (contains? (set valid-attrs) suffix)))
+      (status/die 1 "Unreleased section suffix must be absent or one of:\n %s\nBut found:\n %s"
+                  (string/join ", " valid-attrs)
+                  (pr-str suffix))
+
+      (string/blank? desc)
+      (status/die 1 "Unreleased section has no text describing release")
+
+      :else
+      (status/line :detail "✅ Unreleased section found with text describing release."))))
+
+(defn bump-version
+  "Bump :release in version.edn file while preserving any formatting and comments"
+  []
+  (spit "version.edn"
+        (-> "version.edn"
+            z/of-file
+            (z/find-value z/next :release)
+            z/right
+            (z/edit inc)
+            z/root-string)))
+
+(defn- update-changelog! [version last-version]
+  (status/line :head (str "Updating change log unreleased header to release " version))
+  (update-file! "CHANGELOG.adoc"
+                [["update unreleased header"
+                  #"(?ims)^== Unreleased( ?.*?)(== v\d|\z)"
+                  (str
+                    ;; add Unreleased section for next released
+                    "== Unreleased\n\n"
+                    ;; replace "Unreleased" with actual version
+                    "== v" version
+                    ;; followed by any suffix and section content
+                    "$1"
+                    ;; followed by link to commit log
+                    (when last-version
+                      (str
+                        "https://github.com/clj-commons/etaoin/compare/"
+                        last-version
+                        "\\\\...v"  ;; single backslash is escape for AsciiDoc
+                        version
+                        "[Full commit log]\n\n"))
+                    ;; followed by next section indicator
+                    "$2")]]))
+
+(defn- create-jar! []
+  (status/line :head "Creating jar for release")
+  (shell/clojure "-T:build jar")
+  nil)
+
+(defn- built-version []
+  (-> (shell/clojure {:out :string}
+                     "-T:build built-version")
+      :out
+      string/trim))
+
+(defn- assert-on-ci
+  "Little blocker to save myself from myself when testing."
+  [action]
+  (when (not (System/getenv "CI"))
+    (status/die 1 "We only want to %s from CI" action)))
+
+(defn- deploy-jar!
+  "For this to work, appropriate CLOJARS_USERNAME and CLOJARS_PASSWORD must be in environment."
+  []
+  (status/line :head "Deploying jar to clojars")
+  (assert-on-ci "deploy a jar")
+  (shell/clojure "-T:build deploy")
+  nil)
+
+(defn- commit-changes! [version]
+  (let [tag-version (str "v" version)]
+    (status/line :head (str  "Committing and pushing changes made for " tag-version))
+    (assert-on-ci "commit changes")
+    (status/line :detail "Adding changes")
+    (shell/command "git add doc/01-user-guide.adoc CHANGELOG.adoc version.edn")
+    (status/line :detail "Committing")
+    (shell/command "git commit -m" (str  "Release job: updates for version " tag-version))
+    (status/line :detail "Version tagging")
+    (shell/command "git" "tag" "-a" tag-version "-m" (str  "Release " tag-version))
+    (status/line :detail "Pushing commit")
+    (shell/command "git push")
+    (status/line :detail "Pushing version tag")
+    (shell/command "git push origin" tag-version)
+    nil))
+
+(defn- inform-cljdoc! [version]
+  (status/line :head (str "Informing cljdoc of new version " version))
+  (assert-on-ci "inform cljdoc")
+  (let [exit-code (->  (shell/command {:continue true}
+                                      "curl" "-X" "POST"
+                                      "-d" "project=etaoin/etaoin"
+                                      "-d" (str  "version=" version)
+                                      "https://cljdoc.org/api/request-build2")
+                       :exit)]
+    (when (not (zero? exit-code))
+      (status/line :warn (str  "Informing cljdoc did not seem to work, exited with " exit-code)))))
+
+(def args-usage "Valid args: (prep|deploy-remote|commit|validate|--help)
+
+Commands:
+  prep           Update version, user guide, changelog and create jar
+  deploy-remote  Deploy jar to clojars
+  commit         Commit changes made back to repo, inform cljdoc of release
+
+These commands are expected to be run in order from CI.
+Why the separation?
+To restrict the exposure of our CLOJARS secrets during deploy workflow
+
+Additional commands:
+  validate      Verify that change log is good for release
+
+Options
+  --help        Show this help")
+
+(defn -main [& args]
+  (when-let [opts (main/doc-arg-opt args-usage args)]
+    (cond
+      (get opts "prep")
+      (do (clean!)
+          (validate-changelog)
+          (let [last-version (last-release-tag)]
+            (status/line :detail (str "Last version released: " (or last-version "<none>")))
+            (fs/create-dirs "target")
+            (bump-version)
+            (create-jar!)
+            (let [version (built-version)]
+              (status/line :detail (str "Built version: " version))
+              (update-user-guide! version)
+              (update-changelog! version last-version))))
+
+      (get opts "deploy-remote")
+      (deploy-jar!)
+
+      (get opts "commit")
+      (let [version (built-version)]
+        (commit-changes! version)
+        (inform-cljdoc! version))
+
+      (get opts "validate")
+      (do (validate-changelog)
+          nil))))
+
+(main/when-invoked-as-script
+ (apply -main *command-line-args*))

--- a/version.edn
+++ b/version.edn
@@ -1,0 +1,6 @@
+;; describes last release and is also a template for the next release
+;; :release is incremented by the release workflow is meant to represent the total number of releases
+;; omit :qualifier (ex. :qualifier "alpha") for official releases
+{:major 1
+ :minor 0
+ :release 37}


### PR DESCRIPTION
Mostly cribbed from rewrite-clj.

Currently invoked from GitHub Actions UI.

Version scheme is major.minor.release-count

See new maintainer guide for details.

Closes #422