### PR TITLE
ci: adapt to GitHub actions set-output deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       run: bb ci-release commit
 
     - name: Make GitHub Actions aware of target version tag
-      run: echo "::set-output name=tag::v$(bb clojure -T:build built-version)"
+      run: echo "tag=v$(bb clojure -T:build built-version)" >> $GITHUB_OUTPUT
       id: target-version
 
     - name: Create GitHub release (step 4 of 4)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     - id: set-tests
       name: Set test var for matrix
       # run test.clj directly instead of via bb task to avoid generic task output
-      run: echo "::set-output name=tests::$(bb script/test.clj matrix-for-ci --format=json)"
+      run: echo "tests=$(bb script/test.clj matrix-for-ci --format=json)" >> $GITHUB_OUTPUT
 
   build:
     needs: setup


### PR DESCRIPTION
Closes #501
