### PR TITLE
Address JDK 19 Thread/sleep Clojure interop

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,8 @@ A release with an intentional breaking changes is marked with:
 
 == Unreleased
 
+* https://github.com/clj-commons/etaoin/issues/503[#503]: Address Clojure interop issue introduced by new Thread/sleep signature in JDK 19
+
 == v1.0.38 [minor breaking]
 
 Minor Breaking Changes

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2453,7 +2453,7 @@
   (#_{:clj-kondo/ignore [:unused-binding]} [driver seconds]
    (wait seconds))
   ([seconds]
-   (Thread/sleep (* seconds 1000))))
+   (Thread/sleep ^long (* seconds 1000))))
 
 (defmacro with-wait
   "Execute `body` waiting `seconds` before each form.


### PR DESCRIPTION
JDK 19's Thread/sleep now also accepts a Duration. Add a ^long type hint to remove this new ambiguity for Clojure interop.

Closes #503

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
