### PR TITLE
Bump setup-clojure action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.3
+      uses: DeLaGuardo/setup-clojure@10.1
       with:
         bb: 'latest'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.3
+      uses: DeLaGuardo/setup-clojure@10.1
       with:
         bb: 'latest'
 
@@ -101,7 +101,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.3
+      uses: DeLaGuardo/setup-clojure@10.1
       with:
         bb: 'latest'
 


### PR DESCRIPTION
This might get rid of GitHub Action deprecation warning about save-state

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
