### PR TITLE
Fix: bb repl exited right after launch [skip ci]

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -28,10 +28,10 @@
                                 etaoin/etaoin {:local/root "."}
                                 ;; repeat necessary :test deps from deps.edn
                                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                  :task (babashka.nrepl.server/start-server!)}
+                  :task (do (babashka.nrepl.server/start-server!)
+                            (deref (promise)))}
   test:jvm       {:doc "Runs tests under JVM Clojure [--help]"
                   :task test/test-jvm}
-
   -test:bb       {:doc "bb test runner, invoked within script/test.clj"
                   :requires ([taoensso.timbre :as timbre])
                   ;; repeat :test paths from deps.edn


### PR DESCRIPTION
The dev:bb task now promises to stick around.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [ ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
