### PR TITLE
fix: docker-run now properly supports interactive

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -75,7 +75,7 @@
                                "docker run -it --rm -v"
                                (cond-> [(str (fs/cwd) ":/etaoin")
                                         "-w" "/etaoin"]
-                                 (when-not (seq *command-line-args*)) (conj "--entrypoint" "/bin/bash")
+                                 (not (seq *command-line-args*)) (conj "--entrypoint" "/bin/bash")
                                  :always (conj "etaoin:latest")
                                  :always (concat *command-line-args*)))}
   ci-release     {:doc "release tasks, use --help for args"

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -142,17 +142,22 @@ bb docker-build
 TIP: This will build a docker image with current releases of Chrome, Firefox and their respective WebDrivers.
 Rerun the command as necessary.
 
-You can use this image interactively:
+You can run a single command and exit:
+[source,shell]
+----
+bb docker-run bb test:bb --suites unit
+----
+
+Or use the docker image interactively:
 [source,shell]
 ----
 bb docker-run
-bb test all
 ----
 
-Or you can use it to run a single command:
+And then at the interactive prompt:
 [source,shell]
 ----
-bb docker-run bb test all
+bb test:jvm --suites ide --browsers firefox
 ----
 
 NOTE: `docker-run` plunks you automatically into `/etaoin` which maps to the etaoin project root
@@ -163,7 +168,7 @@ Feel free to run docker commands directly if that is more your thing.
 
 === WebDriver Processes
 
-Sometimes WebDriver process might hang around longer than you'd like.
+Sometimes WebDriver processes might hang around longer than you'd like.
 
 To list them:
 [source,shell]


### PR DESCRIPTION
And docker-run docs updated to use new test tasks

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
