### PR TITLE
ci: ImageMagick is now pre-installed for windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,14 +83,6 @@ jobs:
         key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
         restore-keys: cljdeps-
 
-    - name: Install Missing Windows Bits
-      if: ${{ matrix.os == 'windows' }}
-      run: |
-        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
-        choco install --no-progress --yes imagemagick
-        refreshenv
-        Write-Output "$env:PATH" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
     - name: Setup Java
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
GitHub Actions has added ImageMagick to their Windows images so we no longer need to install it.

Closes #531

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
