### PR TITLE
ci: temp fix for edge webdriver version mismatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,9 +94,13 @@ jobs:
       with:
         bb: 'latest'
 
+    # Delete the following step and associated code when GHA fixes the mismatch
+    - name: Workaround GitHub Actions Edge Browser/WebDriver version mismatch on Windows
+      if: ${{ matrix.os == 'windows' }}
+      run: bb -gha-win-edge-workaround
+
     - name: Tools versions
       run: bb tools-versions
 
     - name: Run Tests
-      # To see all commands: bb test matrix-for-ci
       run: ${{ matrix.cmd }}

--- a/bb.edn
+++ b/bb.edn
@@ -79,4 +79,7 @@
                                  :always (conj "etaoin:latest")
                                  :always (concat *command-line-args*)))}
   ci-release     {:doc "release tasks, use --help for args"
-                  :task ci-release/-main }}}
+                  :task ci-release/-main }
+  -gha-win-edge-workaround {:doc "Deal with Edge browser/Edge WebDriver version mismatch on GitHub Actions"
+                            :requires ([gha-win-edge-workaround])
+                            :task (gha-win-edge-workaround/workaround)}}}

--- a/script/gha_win_edge_workaround.clj
+++ b/script/gha_win_edge_workaround.clj
@@ -1,0 +1,51 @@
+(ns gha-win-edge-workaround
+  (:require [babashka.fs :as fs]
+            [babashka.http-client :as http]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [lread.status-line :as status]
+            [tools-versions]))
+
+;; To be deleted after GitHub Actions team fixes the issue
+
+(defn- tool-info [versions tool-name]
+  (->> versions
+       (filter #(= tool-name (:name %)))
+       first))
+
+(defn- major-version [tool-info]
+  (->> tool-info
+       :version
+       (re-find #"(\d+)\.")
+       last))
+
+(defn workaround []
+  (status/line :head "GHA Windows Edge workaround for mismatch Edge Browser/Edge Webdriver versions")
+  (let [versions (tools-versions/versions)
+        edge (tool-info versions "Edge")
+        edge-webdriver (tool-info versions "Edge Webdriver")]
+    (status/line :detail "Edge info: %s" edge)
+    (status/line :detail "Edge Webdriver info: %s" edge-webdriver)
+    (let [edge-major (major-version edge)
+          edge-webdriver-major (major-version edge-webdriver)]
+      (if (= edge-major edge-webdriver-major)
+        (status/line :detail "Major versions seem to match, all good, nothing to do.")
+        (do
+          (status/line :warn "Edge WebDriver major version %s does not match Edge Browser major version %s\nWill attemp to address."
+                       edge-webdriver-major edge-major)
+          (let [webdriver-version-url (format "https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_RELEASE_%s"
+                                              edge-major)
+                webdriver-version (-> (http/get webdriver-version-url {:as :bytes})
+                                      :body
+                                      (String. "UTF16")
+                                      str/trim)
+                dl-file "edgedriver_win64.zip"
+                dl-url (format "https://msedgedriver.azureedge.net/%s/%s" webdriver-version dl-file)
+                target-path (fs/parent (:path edge-webdriver))]
+            (status/line :detail "Current matching Edge Webdriver version: %s" webdriver-version)
+            (status/line :detail "Downloading: %s" dl-url)
+            (io/copy
+              (:body (http/get dl-url {:as :stream}))
+              (io/file dl-file))
+            (status/line :detail "Replacing Edge Webdriver in %s" target-path)
+            (fs/unzip dl-file target-path {:replace-existing true})))))))


### PR DESCRIPTION
A temporary fix to address a bug in the GitHub Actions Windows runner: it includes the wrong version of the Edge Webdriver.

Can delete this temp fix when GHA resolves their problem.

Closes #538

The following failures are expected and will be addressed separately:
- api macos safari bb/jvm #537 

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
