### PR TITLE
docs: selecting options from dropdowns

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,8 @@ A release with an intentional breaking changes is marked with:
 == Unreleased
 
 * bump all deps to current versions
+* docs
+** https://github.com/clj-commons/etaoin/issues/534[#534]: better describe `etaoin.api/select` and its alternatives
 
 == v1.0.40
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -922,6 +922,62 @@ Another set of functions do the same but move the mouse pointer to a specified e
 A middle mouse click can open a link in a new background tab.
 The right click sometimes is used to imitate a context menu in web applications.
 
+=== Selecting an option from a dropdown [[select-dropdown]]
+
+An `<option>` from a `<select>` can be selected via the `click` function.
+
+Given the following HTML:
+
+[source,html]
+----
+<select id="dropdown" name="options">
+  <option value="o1">foo one</option>
+  <option value="o2">bar two</option>
+  <option value="o3">bar three</option>
+  <option value="o4">bar four</option>
+</select>
+----
+
+Click on option with value `o4`:
+[source,clojure]
+----
+(e/click driver [{:id :dropdown} {:value "o4"}])
+(e/get-element-value driver :dropdown)
+;; => "o4"
+----
+
+Click on option with text `bar three`:
+[source,clojure]
+----
+(e/click driver [{:id :dropdown} {:fn/text "bar three"}])
+(e/get-element-value driver :dropdown)
+;; => "o3"
+----
+
+TIP: Safari Quirk: You might need to first click on the `select` element, then the option.
+
+[NOTE]
+====
+Etaoin also includes the https://cljdoc.org/d/etaoin/etaoin/CURRENT/api/etaoin.api#select[select] convenience function. It will select the first option from a dropdown that includes the specified text. It also automatically handles the Safari quirk.
+
+Click first matching option with text `bar`:
+[source,clojure]
+----
+(e/select driver :dropdown "bar")
+(e/get-element-value driver :dropdown)
+;; => "o2"
+----
+
+The same operation expressed with `click`:
+[source,clojure]
+----
+(e/click driver :dropdown) ;; needed for Safari quirk only
+(e/click driver [{:id :dropdown} {:fn/has-text "bar"}])
+(e/get-element-value driver :dropdown)
+;; => "o2"
+----
+====
+
 === Keyboard Chords
 
 There is an option to input a series of keys simultaneously.

--- a/doc/user-guide-sample.html
+++ b/doc/user-guide-sample.html
@@ -65,9 +65,18 @@
       formal question
       <input id="fq" name="formal-question" type="text" size="80"/>
     </label>
-     <label>
+    <label>
       textarea
       <textarea id="text" name="remarks" rows=3 cols=80></textarea>
+    </label>
+    <label>
+      dropdown
+      <select id="dropdown" name="options">
+        <option value="o1">foo one</option>
+        <option value="o2">bar two</option>
+        <option value="o3">bar three</option>
+        <option value="o4">bar four</option>
+      </select>
     </label>
     <label>
       not enabled

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2956,10 +2956,14 @@
                     :arg     q-text}))))
 
 (defn select
-  "Have `driver` select option with matching `text` for select element found by query `q`.
-  The select element is clicked, then the option.
+  "Convenience function to have `driver` select first option that includes `text` for select element found by query `q`.
 
-  See [[query]] for details on `q`."
+  To appease a quirk of the Safari WebDriver, we click on the select element first, then the option.
+  Other WebDriver implementations do not seem to need, but are not negatively impacted by, the click on the select element.
+
+  See [[query]] for details on `q`.
+
+  See [User Guide](/doc/01-user-guide.adoc#select-dropdown) for other ways to select options from dropdowns."
   [driver q text]
   (let [select-el (query driver q)]
     (click-el driver select-el)


### PR DESCRIPTION
Clearly explain that `etaoin.api/select` is a convenience function and add examples to user guide on other ways to select options from dropdowns.

User guide is run through test-doc-blocks so new example code blocks are verified and part of our test suite.

Closes #534

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
