### PR TITLE
test-doc: user guide: de-flake wikipedia example

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -256,6 +256,7 @@ endif::[]
 
 ;; search for something interesting
 (e/fill driver {:tag :input :name :search} "Clojure programming language")
+(e/wait driver 1)
 (e/fill driver {:tag :input :name :search} k/enter)
 (e/wait-visible driver {:class :mw-search-results})
 
@@ -322,6 +323,7 @@ A portion of the above rewritten with `doto`:
   (e/go "https://en.wikipedia.org/")
   (e/wait-visible [{:id :simpleSearch} {:tag :input :name :search}])
   (e/fill {:tag :input :name :search} "Clojure programming language")
+  (e/wait 1)
   (e/fill {:tag :input :name :search} k/enter)
   (e/wait-visible {:class :mw-search-results})
   (e/click [{:class :mw-search-results} {:class :mw-search-result-heading} {:tag :a}])


### PR DESCRIPTION
I've been noticing a sporadic "stale element" error when running wikipedia examples through test-doc-block.

I'm thinking it might be related to how wikipedia implemented their type-ahead search.

Maybe someday we'll automatically retry on stale element errors, but for now I've introduced a 1 second wait to try and de-flake these examples.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
