### PR TITLE
Add support for wide characters to `fill` functions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,7 +7,8 @@ A release with an intentional breaking changes is marked with:
 
 == Unreleased
 
-* https://github.com/clj-commons/etaoin/pull/552[#552]: Add support for wide characters to fill-human
+* https://github.com/clj-commons/etaoin/pull/552[#552]: Add support for wide characters to input fill functions
+(https://github.com/tupini07[@tupini07])
 * bump all deps to current versions
 * docs
 ** https://github.com/clj-commons/etaoin/issues/534[#534]: better describe `etaoin.api/select` and its alternatives

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ A release with an intentional breaking changes is marked with:
 
 == Unreleased
 
+* https://github.com/clj-commons/etaoin/pull/552[#552]: Add support for wide characters to fill-human
 * bump all deps to current versions
 * docs
 ** https://github.com/clj-commons/etaoin/issues/534[#534]: better describe `etaoin.api/select` and its alternatives

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 - include changes unrelated to the purpose of the PR. This includes changing the project version number, adding lines to the
 `.gitignore` file, or changing the indentation or formatting.
 - open a new PR if changes are requested. Just push to the same branch and the PR will be updated.
-- ever force push on a PR, it makes it too hard to review.
+- never force push on a PR, it makes it too hard to review.
 - overuse vertical whitespace; avoid multiple sequential blank lines.
 
 [1]: https://chris.beams.io/posts/git-commit/#seven-rules

--- a/README.adoc
+++ b/README.adoc
@@ -101,6 +101,7 @@ Can be `alpha`, `beta`, `rc1`, etc.
 * https://github.com/kidd[Raimon Grau]
 * https://github.com/verma[Uday Verma]
 * https://github.com/mjmeintjes[Matt Meintjes]
+* https://github.com/tupini07[Andrea Tupini]
 
 === Current Maintainers
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -855,7 +855,7 @@ which you can choose to override if you wish:
 [source,clojure]
 ----
 (e/refresh driver)
-(e/fill-human driver :uname "soslowsobad"
+(e/fill-human driver :uname "so👻slow🍃sobad"
               {:mistake-prob 0.5
                :pause-max 1})
 
@@ -868,7 +868,7 @@ For multiple inputs, use `fill-human-multi`
 [source,clojure]
 ----
 (e/refresh driver)
-(e/fill-human-multi driver {:uname "login"
+(e/fill-human-multi driver {:uname "login_🪵"
                             :pw "password"
                             :text "some text"}
                            {:mistake-prob 0.1

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -855,12 +855,15 @@ which you can choose to override if you wish:
 [source,clojure]
 ----
 (e/refresh driver)
-(e/fill-human driver :uname "so👻slow🍃sobad"
+(e/fill-human driver :uname "soslowsobad"
               {:mistake-prob 0.5
                :pause-max 1})
 
 ;; or just use default options by omitting them
-(e/fill-human driver :uname " typing human defaults")
+(e/fill-human driver :uname " typing human defaults 👻")
+
+(e/get-element-value driver :uname)
+;; => " typing human defaults 👻"
 ----
 
 For multiple inputs, use `fill-human-multi`

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -838,6 +838,27 @@ You can collect elements into a vector and arbitrarily interact with them at any
 
 Some basic interactions are covered under <<querying>>, here we go into other types of interactions and more detail.
 
+=== UNICODE and Emojis
+As of this writing, Chrome and Edge https://bugs.chromium.org/p/chromedriver/issues/detail?id=2269[only support] filling inputs with UNICODE in the https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane[Basic Multilingual Plane].
+This includes many characters, but not many emojis 😢.
+
+Firefox and Safari seem to support UNICODE more generally 🙂.
+
+[source,clojure]
+----
+(e/with-chrome driver
+  (e/go driver sample-page)
+  (e/fill driver :uname "ⱾⱺⱮⱸ ᢹⓂ Ᵽ")
+  (e/get-element-value driver :uname))
+;; => "ⱾⱺⱮⱸ ᢹⓂ Ᵽ"
+
+(e/with-firefox driver
+  (e/go driver sample-page)
+  (e/fill driver :uname "ⱾⱺⱮⱸ ᢹⓂ Ᵽ plus 👍🔥🙂")
+  (e/get-element-value driver :uname))
+;; => "ⱾⱺⱮⱸ ᢹⓂ Ᵽ plus 👍🔥🙂"
+----
+
 === Emulate how a Real Person Might Type
 
 Real people type slowly and make mistakes.
@@ -860,10 +881,10 @@ which you can choose to override if you wish:
                :pause-max 1})
 
 ;; or just use default options by omitting them
-(e/fill-human driver :uname " typing human defaults 👻")
+(e/fill-human driver :uname " typing human defaults")
 
 (e/get-element-value driver :uname)
-;; => " typing human defaults 👻"
+;; => "soslowsobad typing human defaults"
 ----
 
 For multiple inputs, use `fill-human-multi`
@@ -871,7 +892,7 @@ For multiple inputs, use `fill-human-multi`
 [source,clojure]
 ----
 (e/refresh driver)
-(e/fill-human-multi driver {:uname "login_🪵"
+(e/fill-human-multi driver {:uname "login"
                             :pw "password"
                             :text "some text"}
                            {:mistake-prob 0.1
@@ -2135,7 +2156,7 @@ Example: `:log-level :err`
 
 | `:all`
 
-a| `driver-log-level` *WebDriver* minimal log level.
+a| `:driver-log-level` *WebDriver* minimal log level.
 values vary by browser driver vendor:
 
 * chrome `"OFF"` `"SEVERE"` `"WARNING"` `"INFO"` or `"DEBUG"`

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2809,8 +2809,19 @@
 ;; input
 ;;
 
+(defn- codepoints
+  "Clojure returns a seq of chars for a string.
+  This does not handle wide (unicode) characters.
+  Here we return a seq of codepoint strings for string `s`."
+  [s]
+  (->> s
+       .codePoints
+       .iterator
+       iterator-seq
+       (map #(Character/toString %))))
+
 (defn- make-input* [text & more]
-  (mapv str (apply str text more)))
+  (codepoints (apply str text more)))
 
 (defmulti fill-el
   "Have `driver` fill input element `el` with `text` (and optionally `more` text)."
@@ -2908,17 +2919,13 @@
         wait-key  (fn [] (wait (min (rand) pause-max)))]
     (click-el driver el)
     (wait-key)
-    (doseq [codepoint (->> text
-                           .codePoints
-                           .iterator
-                           iterator-seq
-                           (map #(Character/toString %)))]
+    (doseq [c (codepoints text)]
       (when (< (rand) mistake-prob)
         (fill-el driver el (rand-char))
         (wait-key)
         (fill-el driver el k/backspace)
         (wait-key))
-      (fill-el driver el codepoint)
+      (fill-el driver el c)
       (wait-key))))
 
 (defn fill-human

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2908,13 +2908,17 @@
         wait-key  (fn [] (wait (min (rand) pause-max)))]
     (click-el driver el)
     (wait-key)
-    (doseq [key text]
+    (doseq [codepoint (->> text
+                           .codePoints
+                           .iterator
+                           iterator-seq
+                           (map #(Character/toString %)))]
       (when (< (rand) mistake-prob)
         (fill-el driver el (rand-char))
         (wait-key)
         (fill-el driver el k/backspace)
         (wait-key))
-      (fill-el driver el key)
+      (fill-el driver el codepoint)
       (wait-key))))
 
 (defn fill-human

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -9,7 +9,8 @@
    [etaoin.api :as e]
    [etaoin.impl.util :as util]
    [etaoin.test-report :as test-report]
-   [slingshot.slingshot :refer [try+]]))
+   [slingshot.slingshot :refer [try+]])
+  (:import [java.net URLEncoder]))
 
 (defn numeric? [val]
   (or (instance? Double val)
@@ -106,6 +107,25 @@
       (-> e/get-url
           (str/ends-with? "?login=1&password=2&message=3")
           is)))
+  (testing "fill human input with wide characters"
+    (let [enc (fn [s] (URLEncoder/encode s "UTF-8"))
+          login "log👻in"
+          encoded-login (enc login)
+          pass "12🍂3"
+          encoded-pass (enc pass) 
+          text "t🙌ext"
+          encoded-text (enc text)]
+      (doto *driver*
+        (e/fill-human-multi {:simple-input    login
+                             :simple-password pass
+                             :simple-textarea text})
+        (e/click :simple-submit)
+        (e/when-safari (e/wait 3))
+        (-> e/get-url 
+            (str/ends-with? (str "?login=" encoded-login
+                                 "&password=" encoded-pass
+                                 "&message=" encoded-text))
+            is))))
   (testing "fill human multiple inputs"
     (doto *driver*
       (e/fill-human-multi {:simple-input    "login"

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -109,8 +109,8 @@
   (testing "fill human multiple inputs"
     (doto *driver*
       (e/fill-human-multi {:simple-input    "login"
-                         :simple-password "123"
-                         :simple-textarea "text"})
+                           :simple-password "123"
+                           :simple-textarea "text"})
       (e/click :simple-submit)
       (e/when-safari (e/wait 3))
       (-> e/get-url
@@ -124,6 +124,37 @@
       (-> e/get-url
           (str/ends-with? "?login=1test2+A&password=&message=")
           is))))
+
+(deftest test-unicode-bmp-input
+  (let [data {:simple-input "ĩṋṗṵţ"
+              :simple-password "ǷḁṡṢẅỏṟƉ"
+              :simple-textarea "т️ẹẍṱảṙẸẚ"}]
+    (testing "fill-multi"
+      (e/fill-multi *driver* data)
+      (doseq [f [:simple-input :simple-password :simple-textarea]]
+        (is (= (f data) (e/get-element-value *driver* f)))))
+    (testing "fill-human-multi"
+      (e/refresh *driver*)
+      (e/fill-human-multi *driver* data)
+      (doseq [f [:simple-input :simple-password :simple-textarea]]
+        (is (= (f data) (e/get-element-value *driver* f)))))))
+
+(deftest test-unicode-above-bmp-input
+    ;; as of 2023-04-29 not supported on chrome and edge
+    ;; https://bugs.chromium.org/p/chromedriver/issues/detail?id=2269
+    (when-not (#{:chrome :edge} (e/dispatch-driver *driver*))
+      (let [data {:simple-input "😊🍂input🍃"
+                  :simple-password "🔆password☠️ "
+                  :simple-textarea "🎉🚀textarea👀☀️"}]
+        (testing "fill-multi"
+          (e/fill-multi *driver* data)
+          (doseq [f [:simple-input :simple-password :simple-textarea]]
+            (is (= (f data) (e/get-element-value *driver* f)))))
+        (testing "fill-human-multi"
+          (e/refresh *driver*)
+          (e/fill-human-multi *driver* data)
+          (doseq [f [:simple-input :simple-password :simple-textarea]]
+            (is (= (f data) (e/get-element-value *driver* f))))))))
 
 (deftest test-clear
   (testing "simple clear"

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -106,7 +106,7 @@
       (-> e/get-url
           (str/ends-with? "?login=1&password=2&message=3")
           is)))
-  (testing "fill human multiple imputs"
+  (testing "fill human multiple inputs"
     (doto *driver*
       (e/fill-human-multi {:simple-input    "login"
                          :simple-password "123"

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -9,8 +9,7 @@
    [etaoin.api :as e]
    [etaoin.impl.util :as util]
    [etaoin.test-report :as test-report]
-   [slingshot.slingshot :refer [try+]])
-  (:import [java.net URLEncoder]))
+   [slingshot.slingshot :refer [try+]]))
 
 (defn numeric? [val]
   (or (instance? Double val)
@@ -107,22 +106,6 @@
       (-> e/get-url
           (str/ends-with? "?login=1&password=2&message=3")
           is)))
-  (testing "fill human input with wide characters"
-    (let [enc (fn [s] (URLEncoder/encode s "UTF-8"))
-          login "log👻in"
-          pass "12🍂3"
-          text "t🙌ext"]
-      (doto *driver*
-        (e/fill-human-multi {:simple-input    login
-                             :simple-password pass
-                             :simple-textarea text})
-        (e/click :simple-submit)
-        (e/when-safari (e/wait 3))
-        (-> e/get-url
-            (str/ends-with? (str "?login="    (enc login)
-                                 "&password=" (enc pass)
-                                 "&message="  (enc text)))
-            is))))
   (testing "fill human multiple inputs"
     (doto *driver*
       (e/fill-human-multi {:simple-input    "login"

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -110,21 +110,18 @@
   (testing "fill human input with wide characters"
     (let [enc (fn [s] (URLEncoder/encode s "UTF-8"))
           login "log👻in"
-          encoded-login (enc login)
           pass "12🍂3"
-          encoded-pass (enc pass) 
-          text "t🙌ext"
-          encoded-text (enc text)]
+          text "t🙌ext"]
       (doto *driver*
         (e/fill-human-multi {:simple-input    login
                              :simple-password pass
                              :simple-textarea text})
         (e/click :simple-submit)
         (e/when-safari (e/wait 3))
-        (-> e/get-url 
-            (str/ends-with? (str "?login=" encoded-login
-                                 "&password=" encoded-pass
-                                 "&message=" encoded-text))
+        (-> e/get-url
+            (str/ends-with? (str "?login="    (enc login)
+                                 "&password=" (enc pass)
+                                 "&message="  (enc text)))
             is))))
   (testing "fill human multiple inputs"
     (doto *driver*


### PR DESCRIPTION
Previously, when `api/fill-human` was asked to write text that contained emojis (or other "wide" characters) it would end up writing `??` to the input field instead of the actual emoji. The reason for this is that it was just iterating over every character in the string instead of over the codepoints.

This PR adds support for wide characters to `api/fill-human` by iterating over its codepoints.

Closes #551 

[wokring-codepoints.webm](https://user-images.githubusercontent.com/3422347/235228554-9e1de8cc-4660-4397-b6f6-fd6388130d89.webm)

---

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
