### PR TITLE
Fix jdk8 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: ${{ matrix.jdk-version }}
 
     - name: Install Clojure Tools
       uses: DeLaGuardo/setup-clojure@12.5

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2818,7 +2818,7 @@
        .codePoints
        .iterator
        iterator-seq
-       (map #(Character/toString %))))
+       (map #(String. (Character/toChars %)))))
 
 (defn- make-input* [text & more]
   (codepoints (apply str text more)))


### PR DESCRIPTION
Addendum for #552

Add jdk variants for CI.
Default to jdk 21 but also sanity test on jdks 8, 11 and 17.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
