### PR TITLE
Fix: recognized `:driver-log-level` for Edge

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ A release with an intentional breaking changes is marked with:
 
 * https://github.com/clj-commons/etaoin/pull/552[#552]: Add support for wide characters to input fill functions
 (https://github.com/tupini07[@tupini07])
+* https://github.com/clj-commons/etaoin/issues/566[#566]: Recognize `:driver-log-level` for Edge
 * bump all deps to current versions
 * docs
 ** https://github.com/clj-commons/etaoin/issues/534[#534]: better describe `etaoin.api/select` and its alternatives

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -473,8 +473,8 @@
   (log/infof "The log level setting is not implemented for this driver.")
   driver)
 
-(defmethod set-driver-log-level
-  :chrome
+(defmethods set-driver-log-level
+  [:chrome :edge]
   [driver log-level]
   (set-args driver [(format "--log-level=%s" log-level)]))
 


### PR DESCRIPTION
Also add in sanity tests for WebDrivers that recognize `:driver-log-level`.

Closes #566

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
