### PR TITLE
Fix test command references in user guide

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -209,13 +209,13 @@ bb tools-versions
 +
 [source,bash]
 ----
-bb test all
+bb test:bb
 ----
 * For a smaller sanity test, you might want to run api tests against browsers you are particularly intested in. Example:
 +
 [source,bash]
 ----
-bb test api --browser chrome
+bb test:bb --suites api --browsers chrome
 ----
 
 During the test run, browser windows will open and close in series.


### PR DESCRIPTION
Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [ ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.



This is just a small fix to reference the correct commands, as documented by the CLI help messages, in the docs. I don't know if all of the above applies to such a small, non-code change? :) 