### PR TITLE
ci: temp hack: update windows chrome/chromedriver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,52 @@ jobs:
         brew install --cask firefox
         brew install geckodriver
 
+    # Temporary hack for Windows chrome/chromedriver which seems broken for current Windows image-runner 20240421.1.0
+    # Try do download and install current Chrome browser and appropriate chromedriver just like Windows runner-image does:
+    # https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Install-Chrome.ps1
+    - name: Install Chrome Current
+      if: ${{ matrix.os == 'windows' && contains(matrix.needs, 'chrome') }}
+      run: |
+        Write-Host "Install Chrome Browser..."
+        Install-Binary `
+          -Url 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi' `
+          -ExpectedSignature '2673EA6CC23BEFFDA49AC715B121544098A1284C'
+
+        Write-Host "Install Chrome WebDriver..."
+        $chromeDriverPath = "$($env:SystemDrive)\SeleniumWebDrivers\ChromeDriver"
+        if (-not (Test-Path -Path $chromeDriverPath)) {
+          New-Item -Path $chromeDriverPath -ItemType Directory -Force
+        }
+
+        Write-Host "Get the Chrome WebDriver download URL..."
+        $registryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
+        $chromePath = (Get-ItemProperty "$registryPath\chrome.exe").'(default)'
+        [version] $chromeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($chromePath).ProductVersion
+        $chromeBuild = "$($chromeVersion.Major).$($chromeVersion.Minor).$($chromeVersion.Build)"
+        $chromeDriverVersionsUrl = "https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json"
+
+        Write-Host "Chrome version is $chromeVersion"
+        $chromeDriverVersions = Invoke-RestMethod -Uri $chromeDriverVersionsUrl
+        $chromeDriverVersion = $chromeDriverVersions.builds.$chromeBuild
+
+        if (-not ($chromeDriverVersion)) {
+          $availableVersions = $chromeDriverVersions.builds | Get-Member | Select-Object -ExpandProperty Name
+          Write-Host "Available chromedriver builds are $availableVersions"
+          throw "Can't determine chromedriver version that matches chrome build $chromeBuild"
+        }
+
+        $chromeDriverVersion.version | Out-File -FilePath "$chromeDriverPath\versioninfo.txt" -Force;
+
+        Write-Host "Chrome WebDriver version to install is $($chromeDriverVersion.version)"
+        $chromeDriverZipDownloadUrl = ($chromeDriverVersion.downloads.chromedriver | Where-Object platform -eq "win64").url
+
+        Write-Host "Download Chrome WebDriver from $chromeDriverZipDownloadUrl..."
+        $chromeDriverArchPath = Invoke-DownloadWithRetry $chromeDriverZipDownloadUrl
+
+        Write-Host "Expand Chrome WebDriver archive (without using directory names)..."
+        Expand-7ZipArchive -Path $chromeDriverArchPath -DestinationPath $chromeDriverPath -ExtractMethod "e"
+      shell: pwsh
+
     - uses: actions/checkout@v4
 
     - name: Clojure deps cache


### PR DESCRIPTION
These windows CI failures are becoming annoying.

I looked at various options to update chrome/chromedriver in a Windows image-runner in a throw-away Github repo and found one that seems to work.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
