### PR TITLE
dev: add `--host` to `dev:bb` and `dev:jvm` tasks

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -8,10 +8,18 @@
  :tasks
  {;; setup
   :requires ([babashka.classpath :as cp]
+             [babashka.cli :as cli]
              [babashka.fs :as fs]
              [clojure.string :as string]
              [helper.shell :as shell]
              [lread.status-line :as status])
+  :init (do (defn parse-repl-args [args]
+              (let [cli-spec {:spec
+                              {:host {:desc "Bind to host (use 0.0.0.0 to allow anyone to connect)"
+                                      :alias :h
+                                      :default "localhost"}}
+                              :restrict true}]
+                (cli/parse-opts args cli-spec))))
   :enter (let [{:keys [name]} (current-task)]
            (when-not (string/starts-with? name "-")
              (status/line :head "TASK %s %s" name (string/join " " *command-line-args*))))
@@ -21,7 +29,9 @@
 
   ;; commands
   dev:jvm        {:doc "start a Clojure nrepl server/prompt"
-                  :task (shell/command "clj" "-M:test:repl/cider")}
+                  :task (let [opts (parse-repl-args *command-line-args*)
+                              host (:host opts)]
+                          (shell/command "clj" "-M:test:repl/cider" "-h" host "-b" host))}
   dev:bb         {:doc "start a Babashka nrepl server"
                   ;; repeat :test paths from deps.edn
                   :extra-paths ["test" "env/test/resources"]
@@ -29,8 +39,9 @@
                                 etaoin/etaoin {:local/root "."}
                                 ;; repeat necessary :test deps from deps.edn
                                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                  :task (do (babashka.nrepl.server/start-server!)
-                            (deref (promise)))}
+                  :task (let [opts (parse-repl-args *command-line-args*)]
+                          (babashka.nrepl.server/start-server! opts)
+                          (deref (promise)))}
   test:jvm       {:doc "Runs tests under JVM Clojure [--help]"
                   :task test/test-jvm}
   -test:bb       {:doc "bb test runner, invoked within script/test.clj"

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -90,6 +90,15 @@ For a babashka REPL
 bb dev:bb
 ----
 
+By default you can only connect to the REPL from localhost.
+If you need to connect to a REPL running on a different host, launch your REPL with `--host`.
+For example, to allow anyone to connect to your REPL:
+
+[source,shell]
+----
+bb dev:jvm --host 0.0.0.0
+----
+
 === Checking Tools Versions
 
 Used by GitHub Actions, but also an interesting way to check your prerequisites:


### PR DESCRIPTION
Allows developer to specify `--host 0.0.0.0` to allow anyone to remotely connect. Handy when debugging behaviour on VM or other computer.

Closes #578

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
