### PR TITLE
tests: fix window switch tests

### DIFF
--- a/env/test/resources/static/test2.html
+++ b/env/test/resources/static/test2.html
@@ -4,7 +4,7 @@
         <title>Webdriver Test Document2</title>
     </head>
     <body>
-    <div>
+    <div id="document2">
         <div>
             <div>
                 <ul>
@@ -37,5 +37,6 @@
         </div>
         <a href="">link2</a>
     </div>
+    <h3 id="document-end">Document end</h3>
     </body>
 </html>

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -10,6 +10,7 @@
    [etaoin.api :as e]
    [etaoin.impl.util :as util]
    [etaoin.impl.client :as client]
+   [etaoin.keys :as k]
    [etaoin.test-report :as test-report]
    [slingshot.slingshot :refer [try+]])
   (:import [java.net ServerSocket]))
@@ -489,24 +490,35 @@
 
 (deftest test-switch-window
   (let [init-handle   (e/get-window-handle *driver*)
-        init-url      (e/get-url *driver*)
-        _             (e/click *driver* :switch-window)
-        new-handles   (e/get-window-handles *driver*)
-        new-handle    (first (filter #(not= % init-handle) new-handles))
-        _             (e/switch-window *driver* new-handle)
-        target-handle (e/get-window-handle *driver*)
-        target-url    (e/get-url *driver*)]
-    (is (not= init-handle target-handle))
-    (is (= 2 (count new-handles)))
-    (is (= new-handle target-handle))
-    (is (not= init-url target-url))))
+        init-url      (e/get-url *driver*)]
+    ;; press enter on link instead of clicking (safaridriver is not great with the click)
+    (e/fill *driver* :switch-window k/return)
+    (is (= 2 (count (e/get-window-handles *driver*))) "2 windows now exist")
+    (let [new-handles   (e/get-window-handles *driver*)
+          new-handle    (first (filter #(not= % init-handle) new-handles))
+          _             (e/switch-window *driver* new-handle)
+          target-handle (e/get-window-handle *driver*)
+          target-url    (e/get-url *driver*)]
+      (is (not= init-handle target-handle))
+      (is (= new-handle target-handle))
+      (is (not= init-url target-url)))))
 
 (deftest test-switch-window-next
-  (let [_             (repeat 3 #(e/click *driver* :switch-window))
-        init-handle   (e/get-window-handle *driver*)
-        _             (repeat 4 #(e/switch-window-next *driver*))
-        target-handle (e/get-window-handle *driver*)]
-    (is (= init-handle target-handle))))
+  (let [init-handle (e/get-window-handle *driver*)]
+    (doseq [_ (range 3)]
+      ;; press enter on link instead of clicking (safaridriver is not great with click)
+      (e/fill *driver* :switch-window k/return)
+      ;; compensate: safari navigates to target window, others stay at source
+      (e/when-safari *driver*
+        (e/wait 3) ;; safari seems to need a breather
+        (e/switch-window *driver* init-handle)))
+    (is (= 4 (count (e/get-window-handles *driver*))) "4 windows now exist")
+    (is (= init-handle (e/get-window-handle *driver*)) "on first window")
+    (doseq [_ (range 3)]
+      (e/switch-window-next *driver*)
+      (is (not= init-handle (e/get-window-handle *driver*)) "navigating new windows"))
+    (e/switch-window-next *driver*)
+    (is (= init-handle (e/get-window-handle *driver*)) "wrapped around to original window")))
 
 ;; TODO: need refactoring not working for headless & firefox
 #_
@@ -781,3 +793,22 @@
         (e/perform-actions *driver* keyboard mouse)
         (e/wait 1)
         (is (str/ends-with? (e/get-url *driver*) "?login=1&password=2&message=3"))))))
+
+(comment
+  ;; start test server
+  (def test-server (p/process {:out :inherit :err :inherit} "bb test-server --port" 9993))
+  (def url (format "http://localhost:%d/%s" 9993 "test.html"))
+
+  ;; start your favourite webdriver
+  (def driver (e/safari))
+  (def driver (e/firefox))
+
+  ;; mimic test fixture
+  (e/go driver url)
+  (e/wait-visible driver {:id :document-end})
+
+  ;; cleanup
+  (e/quit driver)
+  (p/destroy test-server)
+
+  :eoc)


### PR DESCRIPTION
Safaridriver is not great with mouse clicks, press enter on link to create new target window instead.

- `test-switch-window` - assert window count earlier for clearer failures
- `test-switch-window-next` - was using unrealized `repeat`s so was effectively testing nothing. Reviewed and rewrote with some compensations for our odd little safaridriver.

Closes #579

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
