### PR TITLE
tests: `test-chrome-profile`: compare real paths

### DIFF
--- a/test/etaoin/unit/unit_test.clj
+++ b/test/etaoin/unit/unit_test.clj
@@ -95,11 +95,12 @@
 
 (deftest test-chrome-profile
   (fs/with-temp-dir [chrome-dir {:prefix "chrome-dir"}]
-    (let [profile-path (str (fs/file chrome-dir "chrome-profile"))]
-      (e/with-chrome {:profile profile-path} driver
+    (let [requested-profile-path (str (fs/file chrome-dir "chrome-profile"))]
+      (e/with-chrome {:profile requested-profile-path} driver
         (e/go driver "chrome://version")
-        (is (= profile-path
-               (e/get-element-text driver :profile_path)))))))
+        (let [chrome-reported-profile-path (e/get-element-text driver :profile_path)]
+          (is (= (str (fs/real-path requested-profile-path))
+                 (str (fs/real-path chrome-reported-profile-path)))))))))
 
 (deftest test-fail-run-driver
   (is (thrown-with-msg?


### PR DESCRIPTION
Something changed somewhere to trigger this, but we should have been comparing real paths all along.

Fixes #582

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
