### PR TITLE
Freshen dev docker test image

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -2598,7 +2598,7 @@ If for some reason you want to reuse a single driver instance for all tests:
 (def ^:dynamic *driver*)
 
 (defn fixture-browser [f]
-  (e/with-chrome-headless {:args ["--no-sandbox"]} driver
+  (e/with-chrome-headless driver
     (e/disconnect-driver driver)
     (binding [*driver* driver]
       (f))
@@ -2632,7 +2632,7 @@ For faster testing you can use this example:
 .....
 
 (defn fixture-browser [f]
-  (e/with-chrome-headless {:args ["--no-sandbox"]} driver
+  (e/with-chrome-headless driver
     (binding [*driver* driver]
       (f))))
 
@@ -3066,10 +3066,8 @@ A common cause for Chrome to crash during startup is running Chrome as root user
 While it is possible to work around this issue by passing --no-sandbox flag when creating your WebDriver session, such a configuration is unsupported and discouraged.
 Ideally you would configure your environment to run Chrome as a regular user instead.
 +
-NOTE: We have noticed that the Selenium docker images always invoke chrome with `--no-sandbox`, so the caveat is a little confusing.
-We've naively replicated this in our own dev docker images.
-Maybe `--no-sandbox` is acceptable, or even needed, when running from a docker container?
-If you have intel here, let us know!
+NOTE: We noticed that the Selenium docker images always invoke chrome with `--no-sandbox`.
+Our link:02-developer-guide.adoc#testing-within-docker[test docker images] don't run from the root user, so we've not bothered with this.
 
 Potential Solution:: Run driver with argument `--no-sandbox`.
 Caution!

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -134,6 +134,7 @@ bb test-doc
 If you are updating the user guide, it preferable if your code block can be run through test-doc-blocks.
 But if this is impractal, you can also have test-doc-blocks skip a code block.
 
+[[testing-within-docker]]
 ==== Testing within Docker
 
 If you wish, you can build a local docker image for testing on Linux.


### PR DESCRIPTION
- bump to jdk21
- install chrome and chromedriver from Chrome for Testing
- chrome launcher name has changed from `google-chrome` to `chrome`, allow for both
- test and install any missing packages
- show progress when downloading drivers/browsers when building image
- old tricks for detecting if we are running from a docker build no longer work, go for a simple file presence check instead
- we don't need `--no-sandbox` for chrome as we are not running from a root user, so we don't need our chrome wrapper

Closes #575

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
