### PR TITLE
dev: cljdoc-preview tweaks [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build.xml
 # ignore lee's fiddling
 /fiddle.clj
 /fiddle/
+/.cljdoc-preview


### PR DESCRIPTION
For security reasons, docker is no longer so happy to write to tmp, so move our cljdoc db dir to `~/.cljdoc-preview`.

Also minor babashka modernizations.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
