### PR TITLE
ci: show webdriver output for flaky os/browsers

### DIFF
--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -40,10 +40,21 @@
 (defn get-default-drivers []
   [:firefox :chrome :safari])
 
+(defn ci? [] (System/getenv "CI"))
+
 (def default-opts
   {:chrome  {}
-   :firefox {}
-   :safari  {}
+   :firefox (cond-> {}
+              ;; add logging for typically flaky CI scenario
+              (and (ci?) (fs/windows?)) (merge {:log-stdout :inherit
+                                                :log-stderr :inherit
+                                                :driver-log-level "trace"}))
+   :safari (cond-> {}
+             ;; add logging for kind flaky CI scenario (maybe we'll answer why we need
+             ;; to retry launching safaridriver automatically)
+             ;; safaridriver only logs details to a somewhat obscure file, will follow up
+             ;; with some technique to discover/dump this file
+             (ci?) (merge {:log-stdout :inherit :log-stderr :inherit}))
    :edge    {:args ["--headless"]}})
 
 (def drivers

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -48,7 +48,7 @@
               ;; add logging for typically flaky CI scenario
               (and (ci?) (fs/windows?)) (merge {:log-stdout :inherit
                                                 :log-stderr :inherit
-                                                :driver-log-level "trace"}))
+                                                :driver-log-level "info"}))
    :safari (cond-> {}
              ;; add logging for kind flaky CI scenario (maybe we'll answer why we need
              ;; to retry launching safaridriver automatically)

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -499,6 +499,8 @@
         init-url      (e/get-url *driver*)]
     ;; press enter on link instead of clicking (safaridriver is not great with the click)
     (e/fill *driver* :switch-window k/return)
+    (e/when-safari *driver*
+      (e/wait 3)) ;;safari seems to need a breather
     (is (= 2 (count (e/get-window-handles *driver*))) "2 windows now exist")
     (let [new-handles   (e/get-window-handles *driver*)
           new-handle    (first (filter #(not= % init-handle) new-handles))

--- a/test/etaoin/unit/proc_test.clj
+++ b/test/etaoin/unit/proc_test.clj
@@ -1,7 +1,6 @@
 (ns etaoin.unit.proc-test
   (:require
    [clojure.java.shell :as shell]
-   [clojure.pprint :as pprint]
    [clojure.string :as str]
    [clojure.test :refer [deftest is]]
    [etaoin.api :as e]
@@ -15,13 +14,6 @@
     (let [instance-report (-> (shell/sh "powershell" "-command" (format "(Get-Process %s -ErrorAction SilentlyContinue).Path" drivername))
                               :out
                               str/split-lines)]
-      ;; more flakiness diagnosis
-      (println "windows" drivername "instance report:" instance-report)
-      (println "windows full list of running processes:")
-      ;; use Get-CimInstance, because Get-Process, does not have commandline available
-      (pprint/pprint (-> (shell/sh "powershell" "-command" "Get-CimInstance Win32_Process | select name, commandline")
-                         :out
-                         str/split-lines))
       (->> instance-report
            (remove #(str/includes? % "\\scoop\\shims\\")) ;; for the scoop users, exclude the shim process
            (filter #(str/includes? % drivername))


### PR DESCRIPTION
We can turf this change if we solve the flakiness.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
