### PR TITLE
doc: user-guide: add list of :fn/*

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ A release with an intentional breaking changes is marked with:
 (https://github.com/tupini07[@tupini07])
 * https://github.com/clj-commons/etaoin/issues/566[#566]: Recognize `:driver-log-level` for Edge
 * bump all deps to current versions
+* https://github.com/clj-commons/etaoin/issues/602[#602]: Document all :fn/* query pseudo-functions in a definitive list
 * tests
 ** https://github.com/clj-commons/etaoin/issues/572[#572]: stop using chrome `--no-sandbox` option, it has become problematic on Windows (and we did not need it anyway)
 * docs

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,12 +11,12 @@ A release with an intentional breaking changes is marked with:
 (https://github.com/tupini07[@tupini07])
 * https://github.com/clj-commons/etaoin/issues/566[#566]: Recognize `:driver-log-level` for Edge
 * bump all deps to current versions
-* https://github.com/clj-commons/etaoin/issues/602[#602]: Document all :fn/* query pseudo-functions in a definitive list
 * tests
 ** https://github.com/clj-commons/etaoin/issues/572[#572]: stop using chrome `--no-sandbox` option, it has become problematic on Windows (and we did not need it anyway)
 * docs
 ** https://github.com/clj-commons/etaoin/issues/534[#534]: better describe `etaoin.api/select` and its alternatives
 ** https://github.com/clj-commons/etaoin/issues/536[#536]: user guide examples are now all os agnostic and CI tested via test-doc-blocks on all supported OSes
+* https://github.com/clj-commons/etaoin/issues/602[#602]: Document all :fn/* query pseudo-functions in a definitive list
 
 == v1.0.40
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -569,39 +569,28 @@ Useful when you need to select a third row from a table, for example.
 * Any non-special key represents an attribute and its value.
 * `:fn/` is a prefix followed by a supported query function.
 
-There are several query functions of the form `:fn/*`. Each query
-function takes a parameter which is the value associated with the
-query function keyword in the map.
+There are several query functions of the form `:fn/*`.
+Each query function takes a parameter which is the value associated with the query function keyword in the map.
 
-* `:fn/text`: Takes a string parameter. Matches if the
-  element has the exact text specified.
-* `:fn/has-text`: Takes a string parameter. Matches if the
-  element includes the specified text.
-* `:fn/has-string`: Takes a string parameter. Matches if the element
-  string contains the specified string. The difference between
-  `:fn/has-text` and `:fn/has-string` is the difference between the
-  XPath `text()` and `string()` functions (`text()` is the text within
-  a given element and `string()` is the text of all descendant
-  elements concatenated together in document order). Generally, if
-  you're targeting an element at the top of the hierarchy, you
-  probably want `:fn/has-string`, and if you're targeting a single
-  element at the bottom of the hierarchy, you probably want to use
-  `:fn/has-text`.
-* `:fn/has-class`: Takes a string parameter. Matches if the element's
-  `class` attribute includes the string. Unlike using a `:class` key
-  in the map, `:fn/has-class` can match single classes, whereas
-  `:class` is an exact match of the whole class string.
-* `:fn/has-classes`: Takes a vector of strings parameter. Matches if
-  the element's `class` attribute includes _all_ of the specified
-  class strings.
-* `:fn/link`: Takes a string parameter. Matches if the element's
-  `href` attribute contains the specified string.
-* `:fn/enabled`: Takes a boolean (`true` or `false`) parameter. If the
-  parameter is `true`, matches if the element is enabled. If the
-  parameter is `false`, matches if the element is disabled.
-* `:fn/disabled`: Takes a boolean (`true` or `false`) parameter. If
-  the parameter is `true`, matches if the element is disabled. If the
-  parameter is `true`, matches if the element is enabled.
+* `:fn/text`: Takes a string parameter. Matches if the element has the exact text specified.
+* `:fn/has-text`: Takes a string parameter.
+  Matches if the element includes the specified text.
+* `:fn/has-string`: Takes a string parameter.
+  Matches if the element string contains the specified string.
+  The difference between `:fn/has-text` and `:fn/has-string` is the difference between the XPath `text()` and `string()` functions (`text()` is the text within a given element and `string()` is the text of all descendant elements concatenated together in document order).
+  Generally, if you're targeting an element at the top of the hierarchy, you probably want `:fn/has-string`, and if you're targeting a single element at the bottom of the hierarchy, you probably want to use `:fn/has-text`.
+* `:fn/has-class`: Takes a string parameter.
+  Matches if the element's `class` attribute includes the string. Unlike using a `:class` key in the map, `:fn/has-class` can match single classes, whereas `:class` is an exact match of the whole class string.
+* `:fn/has-classes`: Takes a vector of strings parameter.
+  Matches if the element's `class` attribute includes _all_ of the specified class strings.
+* `:fn/link`: Takes a string parameter.
+  Matches if the element's `href` attribute contains the specified string.
+* `:fn/enabled`: Takes a boolean (`true` or `false`) parameter.
+  If the parameter is `true`, matches if the element is enabled.
+  If the parameter is `false`, matches if the element is disabled.
+* `:fn/disabled`: Takes a boolean (`true` or `false`) parameter.
+  If the parameter is `true`, matches if the element is disabled.
+  If the parameter is `true`, matches if the element is enabled.
 
 Here are some examples of the map syntax:
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -569,7 +569,41 @@ Useful when you need to select a third row from a table, for example.
 * Any non-special key represents an attribute and its value.
 * `:fn/` is a prefix followed by a supported query function.
 
-Examples:
+There are several query functions of the form `:fn/*`. Each query
+function takes a parameter which is the value associated with the
+query function keyword in the map.
+
+* `:fn/text`: Takes a string parameter. Matches if the
+  element has the exact text specified.
+* `:fn/has-text`: Takes a string parameter. Matches if the
+  element includes the specified text.
+* `:fn/has-string`: Takes a string parameter. Matches if the element
+  string contains the specified string. The difference between
+  `:fn/has-text` and `:fn/has-string` is the difference between the
+  XPath `text()` and `string()` functions (`text()` is the text within
+  a given element and `string()` is the text of all descendant
+  elements concatenated together in document order). Generally, if
+  you're targeting an element at the top of the hierarchy, you
+  probably want `:fn/has-string`, and if you're targeting a single
+  element at the bottom of the hierarchy, you probably want to use
+  `:fn/has-text`.
+* `:fn/has-class`: Takes a string parameter. Matches if the element's
+  `class` attribute includes the string. Unlike using a `:class` key
+  in the map, `:fn/has-class` can match single classes, whereas
+  `:class` is an exact match of the whole class string.
+* `:fn/has-classes`: Takes a vector of strings parameter. Matches if
+  the element's `class` attribute includes _all_ of the specified
+  class strings.
+* `:fn/link`: Takes a string parameter. Matches if the element's
+  `href` attribute contains the specified string.
+* `:fn/enabled`: Takes a boolean (`true` or `false`) parameter. If the
+  parameter is `true`, matches if the element is enabled. If the
+  parameter is `false`, matches if the element is disabled.
+* `:fn/disabled`: Takes a boolean (`true` or `false`) parameter. If
+  the parameter is `true`, matches if the element is disabled. If the
+  parameter is `true`, matches if the element is enabled.
+
+Here are some examples of the map syntax:
 
 * find the first `div` tag
 +


### PR DESCRIPTION
Added a complete list of :fn/* functions that are available in the map syntax. This includes everything in impl/xpath.clj, including :fn/has-string.

Please complete and include the following checklist:

- [ x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [ x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ x] This PR contains test(s) to protect against future regressions

- [ x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
