### PR TITLE
minor breaking: Remove support for PhantomJS

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -7,10 +7,8 @@
            when-not-edge [[:inner 0]]
            when-not-firefox [[:inner 0]]
            when-not-headless [[:inner 0]]
-           when-not-phantom [[:inner 0]]
            when-not-predicate [[:inner 0]]
            when-not-safari [[:inner 0]]
-           when-phantom [[:inner 0]]
            when-predicate [[:inner 0]]
            when-safari [[:inner 0]]
            try+ [[:block 0]]}}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,31 +17,36 @@ A release with an intentional breaking changes is marked with:
 // - unreleased section empty
 // - optional attribute is not [breaking] or [minor breaking]
 //   (adjust these in publish.clj as you see fit)
-== Unreleased
+== Unreleased [minor breaking]
 
-* {pr}552[#552]: Add support for wide characters to input fill functions
+* Technically breaking
+** {issue}613[#612]: Remove all support for long obsolete and long untested PhantomJS
+({lread})
+
+* Other changes
+** {pr}552[#552]: Add support for wide characters to input fill functions
 ({person}tupini07[@tupini07])
-* {issue}566[#566]: Recognize `:driver-log-level` for Edge
+** {issue}566[#566]: Recognize `:driver-log-level` for Edge
 ({lread})
-* {issue}563[#563]: Support `"debug"` `:driver-log-level` for Safari
+** {issue}563[#563]: Support `"debug"` `:driver-log-level` for Safari
 ({lread})
-* {issue}517[#517]: Properly cleanup after failed webdriver launch
+** {issue}517[#517]: Properly cleanup after failed webdriver launch
 ({lread})
-* {issue}604[#604]: Add support for shadow DOM
+** {issue}604[#604]: Add support for shadow DOM
 ({person}dgr[@dgr])
-* {issue}603[#603]: Add :fn/index as alias for :index in map syntax
+** {issue}603[#603]: Add :fn/index as alias for :index in map syntax
 ({person}dgr[@dgr])
-* bump all deps to current versions
+** bump all deps to current versions
 ({lread})
-* tests
-** {issue}572[#572]: stop using chrome `--no-sandbox` option, it has become problematic on Windows (and we did not need it anyway)
+** tests
+*** {issue}572[#572]: stop using chrome `--no-sandbox` option, it has become problematic on Windows (and we did not need it anyway)
 ({lread})
-* docs
-** {issue}534[#534]: better describe `etaoin.api/select` and its alternatives
+** docs
+*** {issue}534[#534]: better describe `etaoin.api/select` and its alternatives
 ({lread})
-** {issue}536[#536]: user guide examples are now all os agnostic and CI tested via test-doc-blocks on all supported OSes
+*** {issue}536[#536]: user guide examples are now all os agnostic and CI tested via test-doc-blocks on all supported OSes
 ({lread})
-** {issue}602[#602]: Document all `:fn/*` query pseudo-functions in a definitive list
+*** {issue}602[#602]: Document all `:fn/*` query pseudo-functions in a definitive list
 ({person}dgr[@dgr])
 
 == v1.0.40 - 2023-03-08 [[v1.0.40]]

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -70,7 +70,6 @@ Etaoin's test suite covers the following OSes and browsers for both Clojure and 
 |===
 
 1. Our GitHub Actions macOS tests run on silicon (aka arm64, aarch64 or M*) hardware
-2. We did once test against PhantomJS, but since work has long ago stopped on this project, we have dropped testing
 
 == Installation
 
@@ -130,7 +129,6 @@ For a quieter Etaoin experience when using babashka, set the timbre default log 
 :url-chromedriver: https://sites.google.com/chromium.org/driver/
 :url-chromedriver-dl: https://sites.google.com/chromium.org/driver/downloads
 :url-geckodriver-dl: https://github.com/mozilla/geckodriver/releases
-:url-phantom-dl: http://phantomjs.org/download.html
 :url-webkit: https://webkit.org/blog/6900/webdriver-support-in-safari-10/
 :url-edge-dl: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
 
@@ -175,12 +173,6 @@ Edge and `msedgedriver` must match so you might need to specify the version:
 `scoop install edgedriver@101.0.1210.0`
 ** Download: link:{url-edge-dl}[Official Microsoft download site]
 
-* Phantom.js browser +
-(obsolete, no longer tested)
-** macOS: `brew install phantomjs`
-** Windows: `scoop install phantomjs`
-** Download: link:{url-phantom-dl}[Official PhantomJS download site]
-
 Check your WebDriver installations launching by launching these commands.
 Each should start a process that includes its own local HTTP server.
 Use Ctrl-C to terminate.
@@ -191,7 +183,6 @@ chromedriver
 geckodriver
 safaridriver -p 0
 msedgedriver
-phantomjs --wd
 ----
 
 You can optionally run the Etaoin test suite to verify your installation.
@@ -1070,7 +1061,7 @@ It acts the same but raises an exception when querying the page returns multiple
 
 Although double-clicking is rarely purposefully employed on web sites, some naive users might think it is the correct way to click on a button or link.
 
-A double-click can be simulated with `double-click` function (Chrome, Phantom.js).
+A double-click can be simulated with `double-click` function (Chrome).
 It can be used, for example, to check your handling of disallowing multiple form submissions.
 
 [source,clojure]
@@ -1812,10 +1803,9 @@ Each map has the following structure:
 ;; => []
 ----
 
-Currently, logs are available in Chrome and Phantom.js only.
+Currently, logs are available in Chrome only.
 The message text and the source type will vary by browser vendor.
 Chrome wipes the logs once they have been read.
-Phantom.js wipes the logs when the page location changes.
 
 === DevTools: Tracking HTTP Requests, XHR (Ajax) [[devtools]]
 
@@ -2343,7 +2333,6 @@ values vary by browser driver vendor:
 ** has only one detailed log level which we enable via its `--diagnose` option and abstract via `"debug"`
 ** only logs to a log file which Etaion automatically discovers and populates as <<opt-driver-log-file>> in the `driver` map
 ** see <<opt-post-stop-fns>> for one way to dump this log file
-* phantomjs "ERROR"` `"WARN"` `"INFO"` `"DEBUG"`
 
 [id=opt-log-stdout,reftext=`:log-stdout`]
 [id=opt-log-stderr,reftext=`:log-sterr`]
@@ -2498,7 +2487,6 @@ Running without a UI is helpful when:
 * running local tests without having them take over your local UI
 
 Ensure your browser supports headless mode by checking if it accepts `--headless` command-line argument when running it from the terminal.
-The Phantom.js driver is headless by its nature (it was never been developed for rendering UI).
 
 When starting a driver, pass the `:headless` boolean flag to switch into headless mode.
 This flag is ignored for Safari which, as of June 2022, still does not support headless mode.
@@ -2525,8 +2513,6 @@ or
 (e/wait 1) ;; seems to appease Firefox on Linux
 (e/quit driver)
 ----
-
-NOTE: PhantomJS will always be in headless mode.
 
 There are several shortcuts to run Chrome or Firefox in headless mode:
 

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -269,4 +269,3 @@ So, when adding any new macros, think also about our Etaoin users and our clj-ko
 
 * https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/[chromedriver]
 * https://github.com/mozilla/geckodriver[firefox geckodriver], https://searchfox.org/mozilla-central/source/testing/webdriver[sources]
-* https://github.com/detro/ghostdriver/blob/[Phantom.js (obsolete, no longer tested)]

--- a/resources/clj-kondo.exports/etaoin/etaoin/config.edn
+++ b/resources/clj-kondo.exports/etaoin/etaoin/config.edn
@@ -12,7 +12,6 @@
    etaoin.api/with-firefox-headless  etaoin.api/with-browser
    etaoin.api/with-edge              etaoin.api/with-browser
    etaoin.api/with-edge-headless     etaoin.api/with-browser
-   etaoin.api/with-phantom           etaoin.api/with-browser
    etaoin.api/with-safari            etaoin.api/with-browser
 
    etaoin.api/with-driver            etaoin.api/with-driver
@@ -26,7 +25,6 @@
    etaoin.api2/with-edge-headless    etaoin.api2/with-browser
    etaoin.api2/with-firefox          etaoin.api2/with-browser
    etaoin.api2/with-firefox-headless etaoin.api2/with-browser
-   etaoin.api2/with-phantom          etaoin.api2/with-browser
    etaoin.api2/with-safari           etaoin.api2/with-browser}}
  :lint-as
  {etaoin.api/with-pointer-left-btn-down clojure.core/->}}

--- a/script/drivers.clj
+++ b/script/drivers.clj
@@ -10,8 +10,7 @@
   [{:name "Chrome" :bin "chromedriver"}
    {:name "Firefox":bin "geckodriver"}
    {:name "Microsoft Edge" :bin "msedgedriver"}
-   {:name "Safari" :bin "safaridriver"}
-   {:name "PhantomJS" :bin "phantomjs"}])
+   {:name "Safari" :bin "safaridriver"}])
 
 (defn driver-processes []
   (->> (ps/all-processes)

--- a/src/etaoin/api2.clj
+++ b/src/etaoin/api2.clj
@@ -56,23 +56,6 @@
   `(e/with-driver :edge ~opts ~bind
      ~@body))
 
-(defmacro with-phantom
-  "Executes `body` with a Phantom.JS driver session bound to `bind`.
-
-  Driver is automatically launched and terminated (even if an exception occurs).
-
-  `opts` - optional, see [Driver Options](/doc/01-user-guide.adoc#driver-options).
-
-  Example:
-
-  ```Clojure
-  (with-phantom [driver]
-    (go driver \"https://clojure.org\"))
-  ```"
-  [[bind & [opts]] & body]
-  `(e/with-driver :phantom ~opts ~bind
-     ~@body))
-
 (defmacro with-safari
   "Executes `body` with a Safari driver session bound to `bind`.
 

--- a/src/etaoin/ide/main.clj
+++ b/src/etaoin/ide/main.clj
@@ -21,7 +21,7 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private browsers-set
-  #{:chrome :safari :firefox :edge :phantom})
+  #{:chrome :safari :firefox :edge})
 
 (defn- str->vec
   [string]

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -86,11 +86,6 @@
   [driver port]
   (set-args driver [(str "--port=" port)]))
 
-(defmethod set-port
-  :phantom
-  [driver port]
-  (set-args driver ["--webdriver" port]))
-
 ;;
 ;; capabilities
 ;;
@@ -263,11 +258,6 @@
   (if-let [args (get-in driver [:capabilities (options-name driver) :args])]
     (contains? (set args) "--headless")
     (:headless driver)))
-
-(defmethod is-headless?
-  :phantom
-  [_driver]
-  true)
 
 ;;
 ;; HTTP proxy
@@ -492,11 +482,6 @@
     (throw (ex-info "Safari Driver only supports debug level logging" {})))
   (-> (set-args driver ["--diagnose"])
       (update :post-run-actions (fnil conj []) :discover-safari-webdriver-log)))
-
-(defmethod set-driver-log-level
-  :phantom
-  [driver log-level]
-  (set-args driver [(format "--webdriver-loglevel=%s" log-level)]))
 
 ;;
 ;; User-Agent

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -251,21 +251,20 @@
 
 ;; In Safari, alerts work quite slow, so we add some delays.
 (deftest test-alert
-  (e/when-not-phantom  *driver*
-    (doto *driver*
-      (e/click {:id :button-alert})
-      (e/when-safari (e/wait 1))
-      (-> e/get-alert-text (= "Hello!") is)
-      (-> e/has-alert? is)
-      (e/accept-alert)
-      (e/when-safari (e/wait 1))
-      (-> e/has-alert? not is)
-      (e/click {:id :button-alert})
-      (e/when-safari (e/wait 1))
-      (-> e/has-alert? is)
-      (e/dismiss-alert)
-      (e/when-safari (e/wait 1))
-      (-> e/has-alert? not is))))
+  (doto *driver*
+    (e/click {:id :button-alert})
+    (e/when-safari (e/wait 1))
+    (-> e/get-alert-text (= "Hello!") is)
+    (-> e/has-alert? is)
+    (e/accept-alert)
+    (e/when-safari (e/wait 1))
+    (-> e/has-alert? not is)
+    (e/click {:id :button-alert})
+    (e/when-safari (e/wait 1))
+    (-> e/has-alert? is)
+    (e/dismiss-alert)
+    (e/when-safari (e/wait 1))
+    (-> e/has-alert? not is)))
 
 (deftest test-properties
   (e/when-firefox *driver*
@@ -483,7 +482,7 @@
 
 (deftest test-window-position
   (e/when-not-drivers
-      [:phantom :edge] *driver*
+    [:edge] *driver*
       (let [{:keys [x y]} (e/get-window-position *driver*)]
         (is (numeric? x))
         (is (numeric? y))
@@ -597,11 +596,9 @@
                      :secure false
                      :value "test2"}))))
   (testing "deleting a cookie"
-    (e/when-not-phantom
-      *driver*
-      (e/delete-cookie *driver* :cookie3)
-      (let [cookie (e/get-cookie *driver* :cookie3)]
-        (is (nil? cookie)))))
+    (e/delete-cookie *driver* :cookie3)
+    (let [cookie (e/get-cookie *driver* :cookie3)]
+      (is (nil? cookie))))
   (testing "deleting all cookies"
     (doto *driver*
       e/delete-cookies
@@ -611,9 +608,7 @@
 
 (deftest test-page-source
   (let [src (e/get-source *driver*)]
-    (if (e/phantom? *driver*)
-      (is (str/starts-with? src "<!DOCTYPE html>"))
-      (is (str/starts-with? src "<html><head>")))))
+    (is (str/starts-with? src "<html><head>"))))
 
 (defn- valid-image? [file]
   (if-let [image-magick (some-> (fs/which (if (= "Linux" (os-name))
@@ -790,29 +785,28 @@
 
 (deftest test-actions
   (testing "input key and mouse click"
-    (e/when-not-phantom *driver*
-      (let [input    (e/query *driver* :simple-input)
-            password (e/query *driver* :simple-password)
-            textarea (e/query *driver* :simple-textarea)
-            submit   (e/query *driver* :simple-submit)
-            keyboard (-> (e/make-key-input)
-                         e/add-double-pause
-                         (e/with-key-down "\uE01B")
-                         e/add-double-pause
-                         (e/with-key-down "\uE01C")
-                         e/add-double-pause
-                         (e/with-key-down "\uE01D"))
-            mouse    (-> (e/make-mouse-input)
-                         (e/add-pointer-click-el input)
-                         e/add-pause
-                         (e/add-pointer-click-el password)
-                         e/add-pause
-                         (e/add-pointer-click-el textarea)
-                         e/add-pause
-                         (e/add-pointer-click-el submit))]
-        (e/perform-actions *driver* keyboard mouse)
-        (e/wait 1)
-        (is (str/ends-with? (e/get-url *driver*) "?login=1&password=2&message=3"))))))
+    (let [input    (e/query *driver* :simple-input)
+          password (e/query *driver* :simple-password)
+          textarea (e/query *driver* :simple-textarea)
+          submit   (e/query *driver* :simple-submit)
+          keyboard (-> (e/make-key-input)
+                       e/add-double-pause
+                       (e/with-key-down "\uE01B")
+                       e/add-double-pause
+                       (e/with-key-down "\uE01C")
+                       e/add-double-pause
+                       (e/with-key-down "\uE01D"))
+          mouse    (-> (e/make-mouse-input)
+                       (e/add-pointer-click-el input)
+                       e/add-pause
+                       (e/add-pointer-click-el password)
+                       e/add-pause
+                       (e/add-pointer-click-el textarea)
+                       e/add-pause
+                       (e/add-pointer-click-el submit))]
+      (e/perform-actions *driver* keyboard mouse)
+      (e/wait 1)
+      (is (str/ends-with? (e/get-url *driver*) "?login=1&password=2&message=3")))))
 
 (deftest test-shadow-dom
   (testing "basic functional sanity"


### PR DESCRIPTION
PhantomJS is long obsolete, and we dropped testing for it long ago. Supporting API, code and docs are clutter at this point.

Closes #612

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
