### PR TITLE
Move to w3c WebDriver spec

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:config-paths ^:replace ;; don't adopt any user preferences
  ["hooks" ;; keep our internal hooks separate from imported ones
   "../resources/clj-kondo.exports/etaoin/etaoin"] ;; include our exported public config
+ :output {:linter-name true}
  :cljc {:features [:clj]} ;; our bb reader conditionals might make some tools also assume cljs, state otherwise
  :hooks
  ;; for internal stuff, I'm fine with using macroexpand, our external config uses analyze-call for

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,8 +22,38 @@ A release with an intentional breaking changes is marked with:
 * Technically breaking
 ** {issue}613[#612]: Remove all support for long obsolete and long untested PhantomJS
 ({lread})
+** {issue}467[#467]: Move to W3C WebDriver spec.
+({lread})
+*** The impetus was Firefox no longer supporting legacy `:capabilities` syntax.
+The breaking impact was on Chrome/Edge, when in "w3c mode" it will fail on WebDriver endpoints where there is a viable w3c alternative.
+This means some custom Chrome specific fns should now be expressed as w3c WebDriver actions.
+The following Chrome-specific fns have been deleted:
+**** `mouse-btn-down`
+**** `mouse-btn-up`
+**** `with-mouse-btn`
+**** `mouse-move-to` (was also available in Firefox)
+**** `mouse-click`
+**** `right-click`
+**** `left-click`
+**** `touch-down`
+**** `touch-move`
+**** `touch-up`
+*** Remove internal support for undocumented `:desired-capabilities`.
+The implementation was either ultra legacy or misunderstood legacy APIs.
 
 * Other changes
+** Add new fns that more lightly abstract W3C WebDriver Spec (as part of {issue}467[#467] API review sweep)
+({lread})
+*** `get-timeouts` - as alternative to `get-*-timeout`
+*** `set-timeouts` - as alternative to `set-*-timeout`
+*** `get-element-rect` - as alternative to `get-element-size`, `get-element-location`
+*** `get-element-rect-el` - as alternative to `get-element-size-el`, `get-element-location-el`
+*** `get-window-rect` - as alternative to `get-window-size`, `get-window-position`
+*** `set-window-rect` - as alternative to `set-window-size`, `set-window-position`
+** Review tests and add some missing coverage (as part of {issue}467[#467] API review sweep)
+({lread})
+** {issue}467[#467]: Required a full sweep of the API, so also includes:
+({lread})
 ** {pr}552[#552]: Add support for wide characters to input fill functions
 ({person}tupini07[@tupini07])
 ** {issue}566[#566]: Recognize `:driver-log-level` for Edge
@@ -48,6 +78,8 @@ A release with an intentional breaking changes is marked with:
 ({lread})
 *** {issue}602[#602]: Document all `:fn/*` query pseudo-functions in a definitive list
 ({person}dgr[@dgr])
+*** {issue}484[#484]: Add W3C WebDriver Spec links to docstrings
+*** {issue}522[#522]: Via better docstrings on getting properties
 
 == v1.0.40 - 2023-03-08 [[v1.0.40]]
 

--- a/bb.edn
+++ b/bb.edn
@@ -66,8 +66,10 @@
                   :task test-server/-main}
   test:bb        {:doc "Runs tests under Babashka [--help]"
                   :task test/test-bb}
-  test-doc       {:doc "test code blocks in user guide"
+  test-doc       {:doc "Test code blocks in user guide"
                   :task test-doc/test-doc}
+  test-coverage  {:doc "Run doc and unit tests on JVM and generate ./target/clofidence code coverage report"
+                  :task test-coverage/-main}
   test-matrix    {:doc "Returns a test matrix for CI [--help]"
                   :task test-matrix/-main}
   drivers        {:doc "[list|kill] any running WebDrivers"

--- a/deps.edn
+++ b/deps.edn
@@ -52,8 +52,8 @@
               :main-opts ["-m" "babashka.cli.exec"]}
 
   :clofidence {:classpath-overrides {org.clojure/clojure nil}
-               :extra-deps {com.github.flow-storm/clojure {:mvn/version "LATEST"} ; >= 1.11.1-15
-                            com.github.flow-storm/clofidence {:mvn/version "LATEST"}}
+               :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.4"}
+                            com.github.flow-storm/clofidence {:mvn/version "0.3.1"}}
                :exec-fn clofidence.main/run
                :exec-args {:report-name "Etaoin Test Coverage"
                            :output-folder "target/clofidence"

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
  :aliases
  {;; we use babashka/neil for project attributes
   ;; publish workflow references these values (and automatically bumps patch component of version)
-  :neil {:project {:version "1.0.40" ;; describes last release and is template for next release
+  :neil {:project {:version "1.1.40" ;; describes last release and is template for next release
                    :name  etaoin/etaoin
                    ;; not neilisms - could potentially conflict with new neilisms
                    :github-coords clj-commons/etaoin}}
@@ -50,6 +50,16 @@
                                           :patterns [:string]
                                           :vars [:symbol]}}
               :main-opts ["-m" "babashka.cli.exec"]}
+
+  :clofidence {:classpath-overrides {org.clojure/clojure nil}
+               :extra-deps {com.github.flow-storm/clojure {:mvn/version "LATEST"} ; >= 1.11.1-15
+                            com.github.flow-storm/clofidence {:mvn/version "LATEST"}}
+               :exec-fn clofidence.main/run
+               :exec-args {:report-name "Etaoin Test Coverage"
+                           :output-folder "target/clofidence"
+                           :test-fn cognitect.test-runner.api/test
+                           :test-fn-args [{:dirs ["test" "target/test-doc-blocks/test"]}]}
+               :jvm-opts ["-Dclojure.storm.instrumentOnlyPrefixes=etaoin"]}
 
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -173,7 +173,7 @@ Edge and `msedgedriver` must match so you might need to specify the version:
 `scoop install edgedriver@101.0.1210.0`
 ** Download: link:{url-edge-dl}[Official Microsoft download site]
 
-Check your WebDriver installations launching by launching these commands.
+Check your WebDriver installations by launching these commands.
 Each should start a process that includes its own local HTTP server.
 Use Ctrl-C to terminate.
 
@@ -190,7 +190,7 @@ You can optionally run the Etaoin test suite to verify your installation.
 TIP: Some Etaoin API tests rely on ImageMagick.
 Install it prior to running test.
 
-From a clone of the https://github.com/clj-commons/etaoin[Etaoin GitHub repo]
+From a clone of the https://github.com/clj-commons/etaoin[Etaoin GitHub repo]:
 
 * To check tools of interest to Etaoin:
 +
@@ -333,7 +333,7 @@ A portion of the above rewritten with `doto`:
 ----
 
 == Playing Along in your REPL
-We encourage you to try the examples in from this user guide in your REPL.
+We encourage you to try the examples from this user guide in your REPL.
 
 The Interwebs is constantly changing.
 This makes testing against live sites impractical.
@@ -385,7 +385,7 @@ into:
 ;; => ["username2" "pass2" "some text2"]
 ----
 
-If any exception occurs during a browser session, the WebDriver process might hang until you kill it manually.
+If any exception occurs during a browser session, the WebDriver process might hang around until you kill it manually.
 To prevent that, we recommend the `with-<browser>` macros:
 
 [source,clojure]
@@ -939,7 +939,7 @@ The `query-shadow-root-el` and `query-all-shadow-root-el` allow you to specify t
 (def shadow-root (e/get-element-shadow-root-el driver host))
 (e/get-element-text-el driver (e/query-shadow-root-el driver shadow-root {:css "#in-shadow"}))
 ;; => "I'm in the shadow DOM"
- 
+
 (->> (e/query-all-shadow-root-el driver shadow-root {:css "span"})
      (map #(e/get-element-text-el driver %)))
 ;; > ("I'm in the shadow DOM" "I'm also in the shadow DOM")
@@ -1069,17 +1069,7 @@ It can be used, for example, to check your handling of disallowing multiple form
 (e/double-click driver {:tag :button :name "submit"})
 ----
 
-There are also "blind" clicking functions.
-They trigger mouse clicks on the current mouse position:
-
-[source,clojure]
-----
-(e/left-click driver)
-(e/middle-click driver)
-(e/right-click driver)
-----
-
-Another set of functions do the same but move the mouse pointer to a specified element before clicking on them:
+Functions that move the mouse pointer to a specified element before clicking on it:
 
 [source,clojure]
 ----
@@ -1575,7 +1565,7 @@ The `:eager` option only works with Firefox at the moment.
 
 Etaoin supports link:{actions}[Webdriver Actions].
 They are described as "virtual input devices".
-They act as little device input scripts that run simultaneously.
+They act as little device input scripts that can even be run simultaneously.
 
 Here, in raw form, we have an example of two actions.
 One controls the keyboard, the other the pointer (mouse).
@@ -2315,6 +2305,8 @@ From least to most verbose:
 * `:debug`
 * `:all` for all messages.
 
+Applies to Chrome and Edge only.
+
 See <<console-logs>>
 
 [id=opt-driver-log-level,reftext=`:driver-log-level`]
@@ -2473,9 +2465,9 @@ _Default:_ <not set>
 
 _Example:_ See <<http-proxy>> for an example usage.
 
-A *WebDriver*'s capabilities can be vendor specific and define preferred options.
+A *WebDriver*'s capabilities can be vendor-specific and define preferred options.
 Read WebDriver vendor docs before setting anything here.
-While reading docs, note that Etaoin passes along `:capabilities` as `desiredCapabilties`.
+While reading docs, note that Etaoin passes along `:capabilities` under `firstMatch`.
 
 === Using Headless Drivers [[headless]]
 
@@ -2489,7 +2481,7 @@ Running without a UI is helpful when:
 Ensure your browser supports headless mode by checking if it accepts `--headless` command-line argument when running it from the terminal.
 
 When starting a driver, pass the `:headless` boolean flag to switch into headless mode.
-This flag is ignored for Safari which, as of June 2022, still does not support headless mode.
+This flag is ignored for Safari which, as of August 2024, still does not support headless mode.
 
 //{:test-doc-blocks/test-ns user-guide-headless-test}
 [source,clojure]
@@ -2566,7 +2558,7 @@ To specify a directory where the browser should download files, use the `:downlo
 ----
 
 Now, when you click on a download link, the file will be saved to that folder.
-Currently, only Chrome and Firefox are supported.
+Currently, only Chrome, Edge and Firefox are supported.
 
 Firefox requires specifying MIME-types of the files that should be downloaded without showing a system dialog.
 By default, when the `:download-dir` parameter is passed, the library adds the most common MIME-types: archives, media files, office documents, etc.
@@ -2598,7 +2590,7 @@ Set a custom `User-Agent` header with the `:user-agent` option when creating a d
 ----
 
 Setting this header is important when using <<headless,headless browsers>> as many websites implement some sort of blocking when the User-Agent includes the "headless" string.
-This can lead to 403 response or some weird behavior of the site.
+This can lead to 403 responses or some weird behavior of the site.
 
 === HTTP Proxy [[http-proxy]]
 
@@ -2622,7 +2614,7 @@ To set proxy settings use environment variables `HTTP_PROXY`/`HTTPS_PROXY` or pa
 NOTE: A `:pac-url` is for a https://en.wikipedia.org/wiki/Proxy_auto-config#The_PAC_File[proxy autoconfiguration file].
 Used with Safari as other proxy options do not work in Safari.
 
-To fine tune the proxy you use the original https://www.w3.org/TR/webdriver/#proxy[object] and pass it to capabilities:
+To fine tune the proxy you use the original https://www.w3.org/TR/webdriver/#proxy[object] and pass it as capabilities:
 
 //:test-doc-blocks/skip
 [source,clojure]

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -237,6 +237,20 @@ Run `bb cljdoc-preview --help` for help.
 * `bb cljdoc-preview view` opens a view to your imported docs in your default web browser
 * `bb cljdoc-preview stop` stops the docker image
 
+=== Test Coverage
+Sometimes it's nice to get an idea of what parts of Etaoin its unit and doc tests (or more importantly, don't) cover.
+
+[source,shell]
+----
+bb test-coverage
+----
+
+The intent is not to strive for some percentage of coverage, just information on what is not covered.
+
+When possible, run from macOS, the only OS where we hit all supported browsers (you'll need all browsers and WebDrivers installed and up to date).
+
+It will take a while, but after tests are complete, crack open `./target/clofidence/index.html` for results.
+
 == Other Notes
 
 === Logging

--- a/env/test/resources/static/test.html
+++ b/env/test/resources/static/test.html
@@ -6,16 +6,16 @@
     </head>
     <body>
 
-
         <h3>Click section</h3>
         <script>
             function fill() {
                 document.getElementById("baz").innerHTML = "clicked";
             }
-        </script>
+
+       </script>
         <button id="foo" onclick="fill()">Click me</button>
         <span id="baz"></span>
-        <hr>
+       <hr>
 
         <h3>CSS section</h3>
         <style>
@@ -257,7 +257,48 @@
             </template>
         </div>
 
-        <h3 id="document-end">Document end</h3>
+        <hr>
 
+        <h3>Pointer Click Target</h3>
+        <div id="pointerClickTarget" style="border: 1px solid black;">
+            [not clicked]
+        </div>
+
+        <h3>Mouse Button State</h3>
+        <pre id="mouseButtonState">[no clicks yet]</pre>
+
+        <h3 id="document-end">Document end</h3>
+        <script>
+            // Mouse button state, taken from:
+            // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+            const buttonNames = ["left", "right", "wheel", "back", "forward"];
+            function mouseButtonPressed(event, buttonName) {
+               // Use binary `&` with the relevant power of 2 to check if a given button is pressed
+               return Boolean(event.buttons & (1 << buttonNames.indexOf(buttonName)));
+            }
+
+            function format(event) {
+              const { type, buttons } = event;
+              const obj = { type };
+              for (const buttonName of buttonNames) {
+                obj[buttonName] = mouseButtonPressed(event, buttonName);
+              }
+              return JSON.stringify(obj, null, 2);
+            }
+
+            const log = document.getElementById("log");
+            function logButtons(event) {
+              // Avoid interfering with form elements
+              mouseButtonState.textContent = format(event);
+            }
+            document.addEventListener("mouseup", logButtons);
+            document.addEventListener("mousedown", logButtons);
+
+            // pointer click target
+            const pointerClickTarget = document.getElementById("pointerClickTarget");
+            pointerClickTarget.addEventListener("dblclick", (e) => {
+                pointerClickTarget.textContent = "[double clicked]";
+            });
+        </script>
     </body>
 </html>

--- a/script/test_coverage.clj
+++ b/script/test_coverage.clj
@@ -1,0 +1,17 @@
+(ns test-coverage
+  (:require [babashka.fs :as fs]
+            [helper.shell :as shell]
+            [lread.status-line :as status]))
+
+(defn generate-doc-tests []
+  (status/line :head "Generating tests for code blocks in documents")
+  (shell/command "clojure -X:test-doc-blocks gen-tests"))
+
+(defn run-all-tests []
+  (status/line :head "Running unit and code block tests under Clojure for coverage report")
+  (shell/command "clojure" "-X:test:test-docs:clofidence"))
+
+(defn -main [& _args]
+  (fs/delete-tree "./target/clofidence")
+  (generate-doc-tests)
+  (run-all-tests))

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -149,7 +149,6 @@
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.set :as cset]
    [clojure.tools.logging :as log]
    [etaoin.impl.client :as client]
    [etaoin.impl.driver :as drv]

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -40,6 +40,11 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- osify-path [s]
+  (-> s
+      fs/file
+      str))
+
 (defn dispatch-driver
   [driver & _]
   (:type driver))
@@ -171,8 +176,8 @@
                   profile)
         user-data-dir (str (fs/parent profile))
         profile-dir   (str  (fs/file-name profile))]
-    (add-browser-args driver [(format "--user-data-dir=%s" user-data-dir)
-                                      (format "--profile-directory=%s" profile-dir)])))
+    (add-browser-args driver [(format "--user-data-dir=%s" (osify-path user-data-dir))
+                              (format "--profile-directory=%s" (osify-path profile-dir))])))
 
 (defmethod set-profile
   :firefox
@@ -182,7 +187,7 @@
   ;; says to specify a marionette port manually.
   [driver profile]
   (-> driver
-      (add-browser-args ["-profile" profile])
+      (add-browser-args ["-profile" (osify-path profile)])
       ((fn [driver]
          (if (some #(= "--marionette-port" %) (get-args driver))
            driver
@@ -333,7 +338,7 @@
 (defmethods set-download-dir
   [:chrome :edge]
   [driver path]
-  (set-prefs driver {:download.default_directory   (add-trailing-slash path)
+  (set-prefs driver {:download.default_directory   (-> path osify-path add-trailing-slash)
                      :download.prompt_for_download false}))
 
 (def ^{:private true

--- a/src/etaoin/impl/driver.clj
+++ b/src/etaoin/impl/driver.clj
@@ -31,8 +31,7 @@
   https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
 
   Selenium Python source code for Firefox
-  https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/firefox/options.py
-  "
+  https://github.com/SeleniumHQ/selenium/blob/master/py/selenium/webdriver/firefox/options.py"
   (:require
    [babashka.fs :as fs]
    [clojure.string :as string]
@@ -66,13 +65,15 @@
   [driver]
   (or (:args driver) []))
 
+(defn- unsupported-msg [driver feature]
+  (format "%s does not support %s" (:type driver) feature))
 
 ;;
-;; Port
+;; WebDriver Port - via webdriver command line arg
 ;;
 
 (defmulti set-port
-  "Updates driver's map with the given port added to the args."
+  "Communication port for the webdriver, set as a command line arg."
   {:arglists '([driver port])}
   dispatch-driver)
 
@@ -87,7 +88,7 @@
   (set-args driver [(str "--port=" port)]))
 
 ;;
-;; capabilities
+;; Capabilities - are sent during webdriver session creation
 ;;
 
 (defn set-capabilities
@@ -96,59 +97,67 @@
     (update driver :capabilities deep-merge caps)
     driver))
 
+;;
+;; Load strategy is a w3c webdrive spec capability
+;;
+
 (defn set-load-strategy
+  "Page load strategy is part of the w3c spec"
   [driver strategy]
   (assoc-in driver [:capabilities :pageLoadStrategy] strategy))
 
-
 ;;
-;; options utils
+;; Vendor specific options are specified in capabalities under a vendor specific name
 ;;
 
-(defmulti options-name dispatch-driver) ;; todo nil default
+(defmulti vendor-options-name dispatch-driver) ;; todo nil default
 
-(defmethod options-name
+(defmethod vendor-options-name
   :firefox
   [_driver]
   :moz:firefoxOptions)
 
-(defmethod options-name
+(defmethod vendor-options-name
   :chrome
   [_driver]
-  :chromeOptions)
+  :goog:chromeOptions)
 
-(defmethod options-name
+(defmethod vendor-options-name
   :safari
   [_driver]
-  :safariOptions)
+  :safari:options)
 
-(defmethod options-name
+(defmethod vendor-options-name
   :edge
   [_driver]
-  :edgeOptions)
+  :ms:edgeOptions)
 
-(defmethod options-name
-  :opera
-  [_driver]
-  :operaOptions)
-
-(defn set-options-args
-  "Adds command line arguments for a browser binary (not a driver)."
-  [driver args]
+(defn- update-vendor-capabilities [driver key f val]
   (update-in driver
-             [:capabilities (options-name driver) :args]
-             append-args (map str args)))
+             [:capabilities (vendor-options-name driver) key]
+             f val))
+
+(defn- set-vendor-capabilities [driver key val]
+  (assoc-in driver
+            [:capabilities (vendor-options-name driver) key]
+            val))
+
+(defn add-browser-args
+  "Adds command line arguments for the browser binary (not the webdriver binary)."
+  [driver args]
+  (update-vendor-capabilities driver :args append-args (map str args)))
 
 ;;
-;; Profiles
+;; Profiles - if supported, are set via browser args
 ;;
 
+;; vendor specific
 (defmulti set-profile dispatch-driver)
 
 (defmethod set-profile
   :default
   [driver _profile]
-  (log/infof "This driver doesn't support setting a profile.")
+  (log/infof (unsupported-msg driver "setting a profile"))
   driver)
 
 (defmethod set-profile
@@ -162,8 +171,8 @@
                   profile)
         user-data-dir (str (fs/parent profile))
         profile-dir   (str  (fs/file-name profile))]
-    (set-options-args driver [(format "--user-data-dir=%s" user-data-dir)
-                              (format "--profile-directory=%s" profile-dir)])))
+    (add-browser-args driver [(format "--user-data-dir=%s" user-data-dir)
+                                      (format "--profile-directory=%s" profile-dir)])))
 
 (defmethod set-profile
   :firefox
@@ -173,14 +182,14 @@
   ;; says to specify a marionette port manually.
   [driver profile]
   (-> driver
-      (set-options-args ["-profile" profile])
+      (add-browser-args ["-profile" profile])
       ((fn [driver]
          (if (some #(= "--marionette-port" %) (get-args driver))
            driver
            (set-args driver ["--marionette-port" 2828]))))))
 
 ;;
-;; window size
+;; Browser initial window size, if supported, is set via command line args
 ;;
 
 (defmulti set-window-size
@@ -191,21 +200,21 @@
 (defmethod set-window-size
   :default
   [driver _w _h]
-  (log/infof "This driver doesn't support setting window size.")
+  (log/infof (unsupported-msg driver "setting initial window size"))
   driver)
 
-(defmethod set-window-size
-  :chrome
+(defmethods set-window-size
+  [:chrome :edge]
   [driver w h]
-  (set-options-args driver [(format "--window-size=%s,%s" w h)]))
+  (add-browser-args driver [(format "--window-size=%s,%s" w h)]))
 
 (defmethod set-window-size
   :firefox
   [driver w h]
-  (set-options-args driver ["-width" w "-height" h]))
+  (add-browser-args driver ["-width" w "-height" h]))
 
 ;;
-;; initial URL
+;; Initial URL - Set, if supported, via browser arg
 ;;
 
 (defmulti set-url
@@ -216,19 +225,19 @@
 (defmethod set-url
   :default
   [driver _url]
-  (log/infof "This driver doesn't support setting initial URL.")
+  (log/infof (unsupported-msg driver "setting initial URL to load"))
   driver)
 
 (defmethod set-url
   :firefox
   [driver url]
-  (set-options-args driver ["--new-window" url]))
+  (add-browser-args driver ["--new-window" url]))
 
 ;; Don't know why but Chrome ignores all the --new-window, --app
 ;; or --google-base-url parameters when starting.
 
 ;;
-;; headless feature
+;; Headless mode, if supported, is supported via browser arg
 ;;
 
 (defmulti set-headless
@@ -238,7 +247,7 @@
 (defmethod set-headless
   :default
   [driver]
-  (log/infof "This driver doesn't support setting headless mode.")
+  (log/infof (unsupported-msg driver "headless mode"))
   driver)
 
 (defmethods set-headless
@@ -246,21 +255,16 @@
   [driver]
   (-> driver
       (assoc :headless true)
-      (set-options-args ["--headless"])))
+      (add-browser-args ["--headless"])))
 
-(defmulti is-headless?
-  {:arglists '([driver])}
-  dispatch-driver)
-
-(defmethod is-headless?
-  :default
+(defn is-headless?
   [driver]
-  (if-let [args (get-in driver [:capabilities (options-name driver) :args])]
+  (if-let [args (get-in driver [:capabilities (vendor-options-name driver) :args])]
     (contains? (set args) "--headless")
     (:headless driver)))
 
 ;;
-;; HTTP proxy
+;; HTTP proxy - is part of the w3c webdriver capabilities spec
 ;;
 
 (defn proxy->w3c
@@ -279,12 +283,13 @@
       bypass         (assoc :noProxy bypass))))
 
 (defn set-proxy
+  "The proxy is part of the w3c spec"
   [driver proxy]
   (let [proxy-w3c (proxy->w3c proxy)]
     (set-capabilities driver {:proxy proxy-w3c})))
 
 ;;
-;; Custom preferences
+;; Custom preferences - are vendor specific capabilities
 ;;
 
 (defmulti set-prefs
@@ -294,15 +299,13 @@
 (defmethod set-prefs
   :default
   [driver _prefs]
-  (log/infof "This driver doesn't support setting preferences.")
+  (log/info (unsupported-msg driver "setting vendor preferences"))
   driver)
 
 (defmethods set-prefs
-  [:firefox :chrome]
+  [:firefox :chrome :edge]
   [driver prefs]
-  (update-in driver
-             [:capabilities (options-name driver) :prefs]
-             merge prefs))
+  (update-vendor-capabilities driver :prefs merge prefs))
 
 ;;
 ;; Download folder
@@ -322,20 +325,20 @@
 (defmethod set-download-dir
   :default
   [driver _path]
-  (log/infof "This driver doesn't support setting a download directory.")
+  (log/info (unsupported-msg driver "setting download directory"))
   driver)
 
 ;; https://github.com/rshf/chromedriver/issues/338
 ;; trailing slash is mandatory for Chrome
-(defmethod set-download-dir
-  :chrome
+(defmethods set-download-dir
+  [:chrome :edge]
   [driver path]
   (set-prefs driver {:download.default_directory   (add-trailing-slash path)
                      :download.prompt_for_download false}))
 
 (def ^{:private true
        :doc     "A set of content types that should be downloaded without asking a user."}
-  ff-content-types
+  firefox-content-types
   #{"application/gzip"
     "application/json"
     "application/msword"
@@ -375,25 +378,18 @@
                      :browser.download.folderList     2
                      :browser.download.useDownloadDir true
                      :browser.helperApps.neverAsk.saveToDisk
-                     (string/join ";" ff-content-types)}))
+                     (string/join ";" firefox-content-types)}))
 
 ;;
-;; binary path
+;; Browser binary path - is set under vendor specific capability
 ;;
 
-(defmulti set-binary
-  {:arglists '([driver binary])}
-  dispatch-driver)
-
-(defmethod set-binary
-  :default
+(defn set-browser-binary
   [driver binary]
-  (assoc-in driver
-            [:capabilities (options-name driver) :binary]
-            binary))
+  (set-vendor-capabilities driver :binary binary))
 
 ;;
-;; logging
+;; Browser console logging - is set via vendor specific settings
 ;;
 
 (defn- remap-log-level
@@ -413,11 +409,17 @@
      :crit
      :critical) "SEVERE"
     :all        "ALL"
-    (assert false (format "Logging level %s is unsupported." level))))
+    (assert false (format "Logging level %s is unrecognized." level))))
 
+(comment
+  (remap-log-level :off)
+  (remap-log-level :foo)
+
+  )
 
 ;;
-;; https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities#loggingpreferences-json-object
+;; These used to be supported by loggingPrefs, but with newer capabilities model
+;; are browser specific.
 ;;
 (defmulti set-browser-log-level
   "Sets browser logging level."
@@ -426,11 +428,18 @@
 
 (defmethod set-browser-log-level
   :default
+  [driver _level]
+  (log/info (unsupported-msg driver "setting the browser log level"))
+  driver)
+
+(defmethods set-browser-log-level
+  [:chrome :edge]
   [driver level]
   (assoc-in driver
-            [:capabilities :loggingPrefs :browser]
+            ;; supports: ALL, DEBUG, INFO, WARNING, SEVERE, or OFF.
+            ;; a bit counter-intuitive, but does not go under goog:chromeOptions
+            [:capabilities :goog:loggingPrefs :browser]
             (remap-log-level level)))
-
 
 ;; http://chromedriver.chromium.org/capabilities
 ;; http://chromedriver.chromium.org/logging/performance-log
@@ -448,9 +457,9 @@
   (update driver :capabilities
           (fn [capabilities]
             (-> capabilities
-                (assoc-in [:loggingPrefs :performance]
+                (assoc-in [:goog:loggingPrefs :performance]
                           (remap-log-level level))
-                (assoc-in [(options-name driver) :perfLoggingPrefs]
+                (assoc-in [(vendor-options-name driver) :perfLoggingPrefs]
                           {:enableNetwork                network?
                            :enablePage                   page?
                            :traceCategories              (string/join "," (map name categories))
@@ -458,12 +467,6 @@
 
 (defmulti set-driver-log-level
   dispatch-driver)
-
-(defmethod set-driver-log-level
-  :default
-  [driver _]
-  (log/infof "The log level setting is not implemented for this driver.")
-  driver)
 
 (defmethods set-driver-log-level
   [:chrome :edge]
@@ -484,7 +487,7 @@
       (update :post-run-actions (fnil conj []) :discover-safari-webdriver-log)))
 
 ;;
-;; User-Agent
+;; User-Agent - supported through various custom schemes
 ;; https://stackoverflow.com/questions/29916054/
 ;;
 
@@ -494,17 +497,17 @@
   dispatch-driver)
 
 (defmethods set-user-agent
+  [:default]
+  [driver _user-agent]
+  (log/info (unsupported-msg driver "setting the user-agent" ))
+  driver)
+
+(defmethods set-user-agent
   [:chrome :edge]
   [driver user-agent]
-  (set-options-args driver [(str "--user-agent=" user-agent)]))
+  (add-browser-args driver [(str "--user-agent=" user-agent)]))
 
 (defmethods set-user-agent
   [:firefox]
   [driver user-agent]
   (set-prefs driver {:general.useragent.override user-agent}))
-
-(defmethods set-user-agent
-  [:default]
-  [driver _user-agent]
-  (log/infof "This driver doesn't support setting a user-agent.")
-  driver)

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -493,7 +493,7 @@
     (e/perform-actions *driver*
                        (-> (e/make-mouse-input)
                            (e/add-pointer-move-to-el (e/query *driver* doc))
-                           (e/with-pointer-btn-down k/mouse-left
+                           (e/with-pointer-left-btn-down
                              (e/add-pointer-move-to-el (e/query *driver* trash)))))
     (is (= 3 (count (e/query-all *driver* doc)))
         "doc count at end")))

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -2,6 +2,7 @@
   (:require
    [babashka.fs :as fs]
    [babashka.process :as p]
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -127,6 +128,15 @@
   :once
   report-browsers
   test-server)
+
+(deftest test-navigation
+  (is (= (test-server-url "test.html")  (e/get-url *driver*)) "initial page")
+  (e/go *driver* (test-server-url "test2.html"))
+  (is (= (test-server-url "test2.html")  (e/get-url *driver*)) "navigate to 2nd page")
+  (e/back *driver*)
+  (is (= (test-server-url "test.html")  (e/get-url *driver*)) "back to initial page")
+  (e/forward *driver*)
+  (is (= (test-server-url "test2.html")  (e/get-url *driver*)) "forward to 2nd page"))
 
 (deftest test-visible
   (doto *driver*
@@ -456,17 +466,46 @@
   (doto *driver*
     (e/close-window)))
 
-(deftest test-drag-n-drop
+(deftest test-drag-and-drop
   (let [url   (test-server-url "drag-n-drop/index.html")
         doc   {:class :document}
         trash {:xpath "//div[contains(@class, 'trash')]"}]
-    (doto *driver*
-      (e/go url)
-      (e/drag-and-drop doc trash)
-      (e/drag-and-drop doc trash)
-      (e/drag-and-drop doc trash)
-      (e/drag-and-drop doc trash)
-      (-> (e/absent? doc) is))))
+    (e/go *driver* url)
+    (is (= 4 (count (e/query-all *driver* doc)))
+        "doc count at start")
+
+    (doseq [n (range 1 5)]
+      (e/drag-and-drop *driver* doc trash)
+      (is (= (- 4 n) (count (e/query-all *driver* doc)))
+          (format "doc count after drag and drop # %d" n)))
+
+    (is (e/absent? *driver* doc)
+        "no docs after last drag and drop")))
+
+(deftest test-drag-and-drop-alt
+  (let [url   (test-server-url "drag-n-drop/index.html")
+        doc   {:class :document}
+        trash {:xpath "//div[contains(@class, 'trash')]"}]
+    (e/go *driver* url)
+    (is (= 4 (count (e/query-all *driver* doc)))
+        "doc count at start")
+
+    (e/perform-actions *driver*
+                       (-> (e/make-mouse-input)
+                           (e/add-pointer-move-to-el (e/query *driver* doc))
+                           (e/with-pointer-btn-down k/mouse-left
+                             (e/add-pointer-move-to-el (e/query *driver* trash)))))
+    (is (= 3 (count (e/query-all *driver* doc)))
+        "doc count at end")))
+
+(deftest test-double-click
+  ;; Does not work on Safari 2024-08-10
+  (e/when-not-safari *driver*
+    (e/scroll-bottom *driver*) ;; element needs to be in viewport
+                               ;; TODO: look at wheel action
+    (is (= "[not clicked]" (e/get-element-text *driver* :pointerClickTarget)))
+    (e/double-click *driver* :pointerClickTarget)
+    (is (= "[double clicked]" (e/get-element-text *driver* :pointerClickTarget)))))
 
 (deftest test-element-location
   (let [q             {:id :el-location-input}
@@ -475,6 +514,7 @@
     (is (numeric? x))
     (is (numeric? y))))
 
+;; Still relevant?:
 ;; Here and below: when running a Safari driver,
 ;; you need to unplug your second monitor. That sounds crazy,
 ;; I know. Bun nevertheless, if a Safari window appears on the second
@@ -482,7 +522,8 @@
 
 (deftest test-window-position
   (e/when-not-drivers
-    [:edge] *driver*
+    [:edge] ;; edge fails this test
+    *driver*
       (let [{:keys [x y]} (e/get-window-position *driver*)]
         (is (numeric? x))
         (is (numeric? y))
@@ -535,28 +576,31 @@
     (e/switch-window-next *driver*)
     (is (= init-handle (e/get-window-handle *driver*)) "wrapped around to original window")))
 
-;; TODO: need refactoring not working for headless & firefox
-#_
 (deftest test-maximize
-  (when-not-headless *driver*
-    (let [{:keys [x y]}          (get-window-position *driver*)
-          {:keys [width height]} (get-window-size *driver*)]
-      (maximize *driver*)
-      (let [{x' :x y' :y}                   (get-window-position *driver*)
-            {width' :width height' :height} (get-window-size *driver*)]
-        (is (not= x x'))
-        (is (not= y y'))
-        (is (not= width width'))
-        (is (not= height height'))))))
+  (when-not (e/headless? *driver*) ;; skip for headless
+    (e/set-window-position *driver* 2 2)
+    (let [orig-rect (e/get-window-rect *driver*)
+          target-rect (-> orig-rect
+                          (update :x #(+ % 2))
+                          (update :y #(+ % 2))
+                          (update :width #(- % 5))
+                          (update :height #(- % 5)))]
+      ;; move the window to ensure values will change when maximized
+      (e/set-window-rect *driver* target-rect)
+      (let [moved-rect (e/get-window-rect *driver*)]
+        ;; sanity test for move
+        (is (= target-rect moved-rect))
+        (e/maximize *driver*)
+        (let [maximed-rect (e/get-window-rect *driver*)]
+          (is (not= moved-rect maximed-rect)))))))
 
 (deftest test-active-element
-  (testing "active element"
-    (e/when-not-safari *driver*
-      (doto *driver*
-        (e/click {:id :set-active-el})
-        (-> (e/get-element-attr :active :id)
-            (= "active-el-input")
-            is)))))
+  (e/when-not-safari *driver*
+    (doto *driver*
+      (e/click {:id :set-active-el})
+      (-> (e/get-element-attr :active :id)
+          (= "active-el-input")
+          is))))
 
 (deftest test-element-text
   (let [text (e/get-element-text *driver* {:id :element-text})]
@@ -566,6 +610,9 @@
   (let [{:keys [width height]} (e/get-element-size *driver* {:id :element-text})]
     (is (numeric? width))
     (is (numeric? height))))
+
+(deftest get-element-tag
+  (is (= "TITLE" (str/upper-case (e/get-element-tag *driver* {:tag :title})))))
 
 (deftest test-cookies
   (testing "getting all cookies"
@@ -595,6 +642,11 @@
                      :path "/"
                      :secure false
                      :value "test2"}))))
+  (testing "setting a cookie"
+    (let [cookie {:name "etaoin-testing123" :value "foobarbaz"}]
+      (e/set-cookie *driver* cookie)
+      (is (= cookie
+             (select-keys (e/get-cookie *driver* :etaoin-testing123) [:name :value])))))
   (testing "deleting a cookie"
     (e/delete-cookie *driver* :cookie3)
     (let [cookie (e/get-cookie *driver* :cookie3)]
@@ -637,11 +689,9 @@
     (is (= 3 (count (fs/list-dir dir))))))
 
 (deftest test-screenshot-element
-  (when (or (e/chrome? *driver*)
-            (e/firefox? *driver*))
-    (util/with-tmp-file "screenshot" ".png" path
-      (e/screenshot-element *driver* {:id :css-test} path)
-      (is (valid-image? path)))))
+  (util/with-tmp-file "screenshot" ".png" path
+    (e/screenshot-element *driver* {:id :css-test} path)
+    (is (valid-image? path))))
 
 (deftest test-js-execute
   (testing "simple result"
@@ -783,30 +833,79 @@
 
 ;; actions
 
-(deftest test-actions
-  (testing "input key and mouse click"
-    (let [input    (e/query *driver* :simple-input)
-          password (e/query *driver* :simple-password)
-          textarea (e/query *driver* :simple-textarea)
-          submit   (e/query *driver* :simple-submit)
-          keyboard (-> (e/make-key-input)
-                       e/add-double-pause
-                       (e/with-key-down "\uE01B")
-                       e/add-double-pause
-                       (e/with-key-down "\uE01C")
-                       e/add-double-pause
-                       (e/with-key-down "\uE01D"))
-          mouse    (-> (e/make-mouse-input)
-                       (e/add-pointer-click-el input)
-                       e/add-pause
-                       (e/add-pointer-click-el password)
-                       e/add-pause
-                       (e/add-pointer-click-el textarea)
-                       e/add-pause
-                       (e/add-pointer-click-el submit))]
-      (e/perform-actions *driver* keyboard mouse)
-      (e/wait 1)
-      (is (str/ends-with? (e/get-url *driver*) "?login=1&password=2&message=3")))))
+(deftest test-mouse-state-actions
+  (testing "mouse state and release"
+    (is (= "[no clicks yet]" (e/get-element-text *driver* :mouseButtonState)))
+    (testing "left mouse down"
+      (e/perform-actions *driver* (-> (e/make-mouse-input)
+                                      (e/add-pointer-down)))
+      (let [button-state (-> (e/get-element-text *driver* :mouseButtonState)
+                             (json/parse-string true))]
+        (is (= {:type "mousedown"
+                :left true
+                :right false
+                :wheel false
+                :back false
+                :forward false} button-state))))
+    (e/when-not-safari *driver* ;; safari currently fails behaves differently one 2024-08-10
+      (testing "right mouse down is not additive to left mouse down in new transaction"
+        (e/perform-actions *driver* (-> (e/make-mouse-input)
+                                        (e/add-pointer-down k/mouse-middle)))
+        (let [button-state (-> (e/get-element-text *driver* :mouseButtonState)
+                               (json/parse-string true))]
+          (is (= {:type "mousedown"
+                  :left false
+                  :right false
+                  :wheel true
+                  :back false
+                  :forward false} button-state))))
+      (testing "multiple mouse buttons can be pressed in a single transaction"
+        (e/perform-actions *driver* (-> (e/make-mouse-input)
+                                        (e/add-pointer-down k/mouse-left)
+                                        (e/add-pointer-down k/mouse-middle)))
+        (let [button-state (-> (e/get-element-text *driver* :mouseButtonState)
+                               (json/parse-string true))]
+          (is (= {:type "mousedown"
+                  :left true
+                  :right false
+                  :wheel true
+                  :back false
+                  :forward false} button-state)))))
+    (testing "release actions wipes state"
+      (e/release-actions *driver*)
+      (let [button-state (-> (e/get-element-text *driver* :mouseButtonState)
+                             (json/parse-string true))]
+          (is (= {:type "mouseup"
+                  :left false
+                  :right false
+                  :wheel false
+                  :back false
+                  :forward false} button-state))))))
+
+(deftest test-combined-actions
+    (testing "input key and mouse click"
+        (let [input    (e/query *driver* :simple-input)
+              password (e/query *driver* :simple-password)
+              textarea (e/query *driver* :simple-textarea)
+              submit   (e/query *driver* :simple-submit)
+              keyboard (-> (e/make-key-input)
+                           e/add-double-pause
+                           (e/with-key-down "\uE01B")
+                           e/add-double-pause
+                           (e/with-key-down "\uE01C")
+                           e/add-double-pause
+                           (e/with-key-down "\uE01D"))
+              mouse    (-> (e/make-mouse-input)
+                           (e/add-pointer-click-el input)
+                           e/add-pause
+                           (e/add-pointer-click-el password)
+                           e/add-pause
+                           (e/add-pointer-click-el textarea)
+                           e/add-pause
+                           (e/add-pointer-click-el submit))]
+          (e/perform-actions *driver* keyboard mouse)
+          (e/wait 1)
+          (is (str/ends-with? (e/get-url *driver*) "?login=1&password=2&message=3")))))
 
 (deftest test-shadow-dom
   (testing "basic functional sanity"
@@ -847,12 +946,28 @@
            (->> (e/query-all-shadow-root *driver* {:id "shadow-root-host"} {:css "span"})
                 (mapv #(e/get-element-text-el *driver* %)))))))
 
+(deftest test-timeouts
+  (let [timeouts {:implicit 32134
+                  :script 78921
+                  :pageLoad 98765}]
+    (e/set-timeouts *driver* timeouts)
+    (is (= timeouts (e/get-timeouts *driver*)))
+    (e/set-page-load-timeout *driver* 987)
+    (e/set-implicit-timeout *driver* 876)
+    (e/set-script-timeout *driver* 765)
+    (is (= 987 (e/get-page-load-timeout *driver*)))
+    (is (= 876 (e/get-implicit-timeout *driver*)))
+    (is (= 765 (e/get-script-timeout *driver*)))
+    (is (= {:pageLoad 987000 :implicit 876000 :script 765000}
+           (e/get-timeouts *driver*)))))
+
 (comment
   ;; start test server
   (def test-server (p/process {:out :inherit :err :inherit} "bb test-server --port" 9993))
   (def url (format "http://localhost:%d/%s" 9993 "test.html"))
 
   ;; start your favourite webdriver
+  (def driver (e/chrome))
   (def driver (e/safari))
   (def driver (e/firefox))
 

--- a/test/etaoin/api_with_driver_test.clj
+++ b/test/etaoin/api_with_driver_test.clj
@@ -35,7 +35,6 @@
   :once
   api-test/test-server)
 
-
 (deftest capabilities-population-test
   ;; different browsers support different features and express configuration differently
   ;; a bit brittle, adjust test expectations accordingly when you make changes to capabilities
@@ -73,9 +72,14 @@
                                                :binary "custom-browser-bin"
                                                :args ["--window-size=1122,771"
                                                       "--extra" "--args"
-                                                      "--user-data-dir=some/profile"
+                                                      (if (fs/windows?)
+                                                        "--user-data-dir=some\\profile"
+                                                        "--user-data-dir=some/profile")
                                                       "--profile-directory=dir"]
-                                               :prefs {:download.default_directory "some/download/dir/"
+                                               :prefs {:download.default_directory
+                                                       (if (fs/windows?)
+                                                         "some\\download\\dir\\"
+                                                         "some/download/dir/")
                                                        :download.prompt_for_download false}}}
                          @capabilities))
           :edge (is (= {:pageLoadStrategy :none
@@ -85,7 +89,9 @@
                                          :binary "custom-browser-bin"
                                          :args ["--window-size=1122,771"
                                                 "--extra" "--args"]
-                                         :prefs {:download.default_directory "some/download/dir/"
+                                         :prefs {:download.default_directory (if (fs/windows?)
+                                                                               "some\\download\\dir\\"
+                                                                               "some/download/dir/")
                                                  :download.prompt_for_download false}}}
                        @capabilities))
           :firefox (let [save-to-disk (get-in @capabilities [:moz:firefoxOptions :prefs :browser.helperApps.neverAsk.saveToDisk])
@@ -96,7 +102,9 @@
                                                   :args ["-width" "1122" "-height" "771"
                                                          "--new-window" "https://initial-url"
                                                          "--extra" "--args"
-                                                         "-profile" "some/profile/dir"]
+                                                         "-profile" (if (fs/windows?)
+                                                                          "some\\profile\\dir"
+                                                                          "some/profile/dir")]
                                                   :prefs {:browser.download.dir "some/download/dir"
                                                           :browser.download.folderList 2
                                                           :browser.download.useDownloadDir true}}}

--- a/test/etaoin/unit/unit_test.clj
+++ b/test/etaoin/unit/unit_test.clj
@@ -23,7 +23,6 @@
     (testing "defaults"
       (e/with-firefox driver
         (is (= {:args ["geckodriver" "--port" 12345]
-                :capabilities {:loggingPrefs {:browser "ALL"}}
                 :host "127.0.0.1"
                 :locator "xpath"
                 :port 12345
@@ -67,25 +66,19 @@
         (e/with-firefox {:capabilities {:specified :val2
                                         :some {:deeper {:thing1 100
                                                         :thing3 300
-                                                        :thing5 500}}}
-                         :desired-capabilities {:specified-desired :val3
-                                                :some {:deeper {:thing3 3000
-                                                                :thing6 6000}}}} driver
+                                                        :thing5 500}}}} driver
           (is (>= (System/currentTimeMillis) (:created-epoch-ms driver)))
           (is (= {:args ["geckodriver" "--port" 12345],
                   :capabilities
                   {:default-firefox :val1
                    :default-global :val2
-                   :loggingPrefs {:browser "ALL"},
                    :some {:deeper {:thing0 10
                                    :thing1 100
                                    :thing2 2
-                                   :thing3 3000
+                                   :thing3 300
                                    :thing4 40
-                                   :thing5 500
-                                   :thing6 6000}}
-                   :specified :val2
-                   :specified-desired :val3}
+                                   :thing5 500}}
+                   :specified :val2}
                   :host "127.0.0.1"
                   :locator "xpath"
                   :port 12345
@@ -163,7 +156,6 @@
         ;; safari driver has a default of 4 retries
         (e/with-safari driver
           (is (= {:args ["safaridriver" "--port" 12345]
-                  :capabilities {:loggingPrefs {:browser "ALL"}}
                   :host "127.0.0.1"
                   :locator "xpath"
                   :port 12345


### PR DESCRIPTION
We've been using a `capabilities` syntax for create session that has long been deprecated. Firefox finally forced our hand with geckodriver 0.35.0, which has removed support for the obsolete syntax.

All supported WebDrivers understand the newer syntax.

We used to pass capabilities in as `desiredCapabilities`, we now pass them in as a single item in the `firstMatch` vector. This should match existing behaviour.

Moving to the new capabilities syntax tells `chromedriver` (and `msedgedriver`) that we are running in "w3c mode". This has benefits on Etaoin code. Our many customizations for these WebDrivers are no longer necessary, they now support the W3C WebDriver endpoint spec.

In "w3c mode", chromedriver disallows any endpoints that could be served by W3C WebDriver endpoints.

Notable examples are mouse and touch operations. These are now handled by the W3C WebDriver action endpoints. WebDriver actions are not stand-alone, they are submitted as transaction of steps. As such the following Chrome-specific fns are no longer needed and would be confusing if not deleted:

- `mouse-btn-down`
- `mouse-btn-up`
- `with-mouse-btn`
- `mouse-move-to` (was also available in Firefox)
- `mouse-click`
- `right-click`
- `left-click`
- `touch-down`
- `touch-move`
- `touch-up`

Users will instead express these manipulations via the existing `perform-actions`.

Fns that represent a transaction of actions in themselves remain:
- `drag-and-drop` (from element to element)
- `double-click*` (on an element)
- `*-click-on` (on an element)
- `touch-tap` (on an element)

Verifying that everything worked required a full review of the API.

Some sweeping changes:
- Our recent deletion of PhantomJS support allowed me to streamline many `defmulti`s into `defn`s.
- Added links to W3C WebDriver Spec endpoints to docstrings

Added some fns to expose at the W3C WebDriver Spec granularity:
- `get-timeouts`
- `set-timeouts`
- `get-element-rect`
- `get-element-rect-el`
- `get-element-rect`
- `set-window-rect`
- `get-window-rect`

We have finer grained versions of the above (ex. `get-element-position`, `get-element-size`, etc). We've kept these for backwards compatibility, but if we were starting today, we would have just matched today's W3C WebDriver spec.

Minor fixes/changes:
- Uncomment and fix the maximize test
- Screenshots on elements work on safari, enable them
- Added notes on displayedness to docstrings
- Remove internal support for undocumented `:desired-capabilities`, the implementation was either ultra legacy or misunderstood legacy APIs.

Add `bb test-coverage` task to check what we are not covering with tests

New tests include coverage for:
- `back`
- `forward`
- `set-cookie`
- `release-actions`
- `*-timeout*`
- `double-click`

Closes #467

Incidentally closes #522 via better docstrings on getting properties.

Closes #484 with W3C WebDriver spec endpoint links.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
