### PR TITLE
maint: bump deps to current releases

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"} ;; min clojure version
-        babashka/fs {:mvn/version "0.5.21"}
+        babashka/fs {:mvn/version "0.5.22"}
         babashka/process {:mvn/version "0.5.22"}
         org.babashka/http-client {:mvn/version "0.4.20"}
         slingshot/slingshot {:mvn/version "0.12.2"}
@@ -16,15 +16,15 @@
                    ;; not neilisms - could potentially conflict with new neilisms
                    :github-coords clj-commons/etaoin}}
 
-  :1.11 {:replace-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-  :1.12 {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}}}
+  :1.11 {:replace-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
+  :1.12 {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0-rc1"}}}
   :debug {:extra-paths ["env/dev/resources"]}
   :test {:extra-paths ["test" "env/test/resources" "build"]
          :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                      org.babashka/cli {:mvn/version "0.8.59"}
+                      org.babashka/cli {:mvn/version "0.8.60"}
                       ch.qos.logback/logback-classic {:mvn/version "1.3.14"}
                       ;; for http-client which uses apache http client 4.x which uses commons logging
-                      org.slf4j/jcl-over-slf4j {:mvn/version "2.0.13"}}
+                      org.slf4j/jcl-over-slf4j {:mvn/version "2.0.16"}}
          :exec-fn test-shared/test
          :org.babashka/cli {:coerce {:nses [:symbol]
                                      :patterns [:string]
@@ -33,7 +33,7 @@
   :script {:extra-paths ["script"]}
 
   ;; test-doc-blocks - gen tests
-  :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.11.3"}
+  :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.11.4"}
                                    com.github.lread/test-doc-blocks  {:mvn/version "1.1.20"}}
                     :replace-paths []
                     :ns-default lread.test-doc-blocks
@@ -41,7 +41,7 @@
 
   ;; test-doc-blocks - run tests
   ;; usage: test:test-docs
-  :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
+  :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
               :extra-paths ["target/test-doc-blocks/test"]
               :exec-fn cognitect.test-runner.api/test
               :exec-args {:dirs ["target/test-doc-blocks/test"]}
@@ -61,17 +61,17 @@
                :jvm-opts ["-Dclojure.storm.instrumentOnlyPrefixes=etaoin"]}
 
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.01"}}
               :main-opts ["-m" "clj-kondo.main"]}
 
-  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.2"}}
+  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
              :extra-paths ["test"]
              :main-opts ["-m" "eastwood.lint" {:source-paths ["src"]
                                                :test-paths ["test"]
                                                :add-linters [:performance]
                                                :exclude-linters [:local-shadows-var]}]}
 
-  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.4"}}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
           :extra-paths ["build"]
           :ns-default build}
 
@@ -79,9 +79,9 @@
   ;; caused by, I think, conflicting maven deps
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}}
 
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1201"}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1206"}
                           org.clojure/clojure {:mvn/version "1.11.1"}
-                          org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
+                          org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
                           }
              :main-opts ["-m" "antq.core"
                          "--exclude=ch.qos.logback/logback-classic@1.4.x" ;; requires min jdk 11, we are currently jdk8 compatible
@@ -89,9 +89,9 @@
                          ]}
 
   :repl/cider
-  {:extra-deps {org.clojure/clojure {:mvn/version "1.11.3"}
-                nrepl/nrepl                {:mvn/version "1.2.0"}
-                cider/cider-nrepl          {:mvn/version "0.49.1"}
+  {:extra-deps {org.clojure/clojure {:mvn/version "1.11.4"}
+                nrepl/nrepl                {:mvn/version "1.3.0"}
+                cider/cider-nrepl          {:mvn/version "0.49.2"}
                 refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
    :main-opts  ["-m" "nrepl.cmdline"

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -24,10 +24,8 @@
                    string/trim)
         bb-cp (bbcp/get-classpath)]
 
-    (status/line :detail "- copying configs")
-    (shell/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (shell/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+    (status/line :detail "- copying lib configs and creating cache")
+    (shell/clojure "-M:clj-kondo --parallel --skip-lint --copy-configs --dependencies --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild-cache]}]
   (status/line :head "clj-kondo: cache check")
@@ -51,7 +49,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (shell/clojure {:continue true}
-                       "-M:clj-kondo --lint src test script env deps.edn bb.edn")]
+                       "-M:clj-kondo --parallel --lint src test script env deps.edn bb.edn")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Of note:
- take advantage of clj-kondo's new ability to copy configs and create cache at same time.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
