### PR TITLE
ci: fix msedgedriver download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,10 +101,13 @@ jobs:
       run: |
         brew install --cask microsoft-edge
         EDGE_VERSION=$(defaults read /Applications/Microsoft\ Edge.app/Contents/Info CFBundleShortVersionString)
-        DRIVER_URL="https://msedgedriver.azureedge.net/${EDGE_VERSION}/edgedriver_mac64_m1.zip"
-        curl -o msedgedriver.zip $DRIVER_URL
+        MAJOR_VERSION=$(echo $EDGE_VERSION | cut -d'.' -f1)
+        DRIVER_VERSION=$(curl -s "https://msedgedriver.azureedge.net/LATEST_RELEASE_${MAJOR_VERSION}_MACOS" | iconv -f UTF-16LE -t UTF-8 | tr -d '\r\n')
+        echo "Installing msedgedriver version ${DRIVER_VERSION} for Edge version ${EDGE_VERSION}"
+        DRIVER_URL="https://msedgedriver.azureedge.net/${DRIVER_VERSION}/edgedriver_mac64_m1.zip"
+        wget $DRIVER_URL
         mkdir $RUNNER_TEMP/edgedriver
-        unzip msedgedriver.zip -d $RUNNER_TEMP/edgedriver
+        unzip edgedriver_mac64_m1.zip -d $RUNNER_TEMP/edgedriver
         echo "$RUNNER_TEMP/edgedriver" >> $GITHUB_PATH
 
     # No longer pre-installed on macOS github action runners

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         brew install --cask microsoft-edge
         EDGE_VERSION=$(defaults read /Applications/Microsoft\ Edge.app/Contents/Info CFBundleShortVersionString)
         MAJOR_VERSION=$(echo $EDGE_VERSION | cut -d'.' -f1)
-        DRIVER_VERSION=$(curl -s "https://msedgedriver.azureedge.net/LATEST_RELEASE_${MAJOR_VERSION}_MACOS" | iconv -f UTF-16LE -t UTF-8 | tr -d '\r\n')
+        DRIVER_VERSION=$(curl -s "https://msedgedriver.azureedge.net/LATEST_RELEASE_${MAJOR_VERSION}_MACOS" | iconv -f UTF-16LE -t UTF-8 | sed 's/^\xEF\xBB\xBF//' | tr -d '\r\n')
         echo "Installing msedgedriver version ${DRIVER_VERSION} for Edge version ${EDGE_VERSION}"
         DRIVER_URL="https://msedgedriver.azureedge.net/${DRIVER_VERSION}/edgedriver_mac64_m1.zip"
         wget $DRIVER_URL


### PR DESCRIPTION
There is not always an exact version match of msedgedriver to Edge.

Closes #624

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
