### PR TITLE
Revise fill-human-* doc strings

### DIFF
--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2779,9 +2779,7 @@
 
   See [[query]] for details on `q`.
 
-  `opts`
-  - `:mistake-prob` probability of making a typo (0 to 1.0) (default: `0.1`)
-  - `:pause-max` maximum amount of time in seconds to pause between keystrokes (can be fractional) (default: `0.2`)"
+  See [[fill-human-el]] for details on `opts`."
   ([driver q text]  (fill-human driver q text {}))
   ([driver q text opts]
    (fill-human-el driver (query driver q) text opts)))
@@ -2789,7 +2787,9 @@
 (defn fill-active-human
   "Fills the currently active element with `text` as if it were a real
   human using `opts`. This is a simple convience function wrapped
-  around `get-active-element` and `fill-human-el`."
+  around `get-active-element` and `fill-human-el`.
+
+  See [[fill-human-el]] for details on `opts`."
   ([driver text] (fill-active-human driver text {}))
   ([driver text opts]
    (fill-human-el driver (get-active-element driver) text opts)))
@@ -2803,9 +2803,7 @@
 
   See [[query]] for details on `q`s.
 
-  `opts`
-  - `:mistake-prob` probability of making a typo (0 to 1.0) (default: `0.1`)
-  - `:pause-max` maximum amount of time in seconds to pause between keystrokes (can be fractional) (default: `0.2`)"
+  See [[fill-human-el]] for details on `opts`."
   ([driver q-text]  (fill-human-multi driver q-text {}))
   ([driver q-text opts]
    (cond


### PR DESCRIPTION
Point user at fill-human-el for details on `opts`.

Closes issue #637.

Please complete and include the following checklist:

- [x ] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x ] This PR contains test(s) to protect against future regressions (NOT NEEDED)

- [x ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue. (NOT NEEDED)
