### PR TITLE
Deprecate when-predicate and when-not-predicate

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ A release with an intentional breaking changes is marked with:
 * Docs
 ** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
+** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2619,8 +2619,10 @@
 ;; skip/when driver
 ;;
 
-(defmacro when-not-predicate
-  "Executes `body` when `predicate` returns falsy."
+(defmacro ^{:deprecated "1.1.42"} when-not-predicate
+  "Executes `body` when `predicate` returns falsy.
+
+  Deprecated: Use `clojure.core/when-not` instead."
   [predicate & body]
   `(when-not (~predicate)
      ~@body))
@@ -2628,35 +2630,37 @@
 (defmacro when-not-drivers
   "Executes `body` when browser `driver` is NOT in `browsers`, ex: `#{:chrome :safari}`"
   [browsers driver & body]
-  `(when-not-predicate #((set ~browsers) (dispatch-driver ~driver)) ~@body))
+  `(when-not ((set ~browsers) (driver-type ~driver)) ~@body))
 
 (defmacro when-not-chrome
   "Executes `body` when browser `driver` is NOT Chrome."
   [driver & body]
-  `(when-not-predicate #(chrome? ~driver) ~@body))
+  `(when-not (chrome? ~driver) ~@body))
 
 (defmacro when-not-edge
   "Executes `body` when browser `driver` is NOT Edge."
   [driver & body]
-  `(when-not-predicate #(edge? ~driver) ~@body))
+  `(when-not (edge? ~driver) ~@body))
 
 (defmacro when-not-firefox
   "Executes `body` when browser `driver` is NOT Firefox."
   [driver & body]
-  `(when-not-predicate #(firefox? ~driver) ~@body))
+  `(when-not (firefox? ~driver) ~@body))
 
 (defmacro when-not-safari
   "Executes `body` when browser `driver` is NOT Safari."
   [driver & body]
-  `(when-not-predicate #(safari? ~driver) ~@body))
+  `(when-not (safari? ~driver) ~@body))
 
 (defmacro when-not-headless
   "Executes `body` when browser `driver` is NOT in headless mode."
   [driver & body]
-  `(when-not-predicate #(headless? ~driver) ~@body))
+  `(when-not (headless? ~driver) ~@body))
 
-(defmacro when-predicate
-  "Executes `body` when `predicate` returns truthy."
+(defmacro ^{:deprecated "1.1.42"} when-predicate
+  "Executes `body` when `predicate` returns truthy.
+
+  Deprecated: Use `clojure.core/when` instead."
   [predicate & body]
   `(when (~predicate)
      ~@body))
@@ -2664,27 +2668,27 @@
 (defmacro when-chrome
   "Executes `body` when browser `driver` is Chrome."
   [driver & body]
-  `(when-predicate #(chrome? ~driver) ~@body))
+  `(when (chrome? ~driver) ~@body))
 
 (defmacro when-firefox
   "Executes `body` when browser `driver` is Firefox."
   [driver & body]
-  `(when-predicate #(firefox? ~driver) ~@body))
+  `(when (firefox? ~driver) ~@body))
 
 (defmacro when-edge
   "Executes `body` when browser `driver` is Edge."
   [driver & body]
-  `(when-predicate #(edge? ~driver) ~@body))
+  `(when (edge? ~driver) ~@body))
 
 (defmacro when-safari
   "Executes `body` when browser `driver` is Safari."
   [driver & body]
-  `(when-predicate #(safari? ~driver) ~@body))
+  `(when (safari? ~driver) ~@body))
 
 (defmacro when-headless
   "Executes `body` when the `driver` is in headless mode."
   [driver & body]
-  `(when-predicate #(headless? ~driver) ~@body))
+  `(when (headless? ~driver) ~@body))
 
 ;;
 ;; input

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -143,7 +143,7 @@
   - [[perform-actions]] [[release-actions]]
 
   **Convenience**
-  - [[rand-uuid]] [[when-predicate]] [[when-not-predicate]]
+  - [[rand-uuid]]
   "
   (:require
    [babashka.fs :as fs]


### PR DESCRIPTION
Closes #644 

- Marks `when-predicate` and `when-not-predicate` as deprecated.
- Leaves them in the namespace TOC for now.
- Updates doc strings to suggest using `when` and `when-not` instead.
- Updates CHANGELOG with note about the change.
- Rewrites various other macros that previously used `when-predicate` and `when-not-predicate` to use `when` and `when-not` instead.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
