### PR TITLE
Change fill-active-human to fill-human-active

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,7 +22,7 @@ A release with an intentional breaking changes is marked with:
 * Changes
 ** {issue}559[#559]: Create `query-from` and `query-all-from` as replacements for `child` and `children`. Rewrite logic such that `q` parameter allows for vector syntax similar to `query` and `query-all`. Deprecate `child` and `children`. ({person}dgr[@dgr])
 ** {issue}559[#559]: Make `get-active-element` a public API. This was previously private. ({person}dgr[@dgr])
-** {issue}629[#629]: Added `fill-active-human` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
+** {issue}629[#629]: Added `fill-human-active` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
 ** {issue}620[#620]: Get stricter when unwrapping elements. ({person}dgr[@dgr])
 * Docs
 ** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -57,7 +57,7 @@
 
   **Inputs/Forms**
   - [[fill]] [[fill-active]] [[fill-el]] [[fill-multi]]
-  - [[fill-human]] [[fill-active-human]] [[fill-human-el]] [[fill-human-multi]]
+  - [[fill-human]] [[fill-human-active]] [[fill-human-el]] [[fill-human-multi]]
   - [[select]] [[selected?]] [[selected-el?]]
   - [[upload-file]] [[remote-file]]
   - [[disabled?]] [[enabled?]]
@@ -2797,13 +2797,13 @@
   ([driver q text opts]
    (fill-human-el driver (query driver q) text opts)))
 
-(defn fill-active-human
+(defn fill-human-active
   "Fills the currently active element with `text` as if it were a real
   human using `opts`. This is a simple convience function wrapped
   around `get-active-element` and `fill-human-el`.
 
   See [[fill-human-el]] for details on `opts`."
-  ([driver text] (fill-active-human driver text {}))
+  ([driver text] (fill-human-active driver text {}))
   ([driver text opts]
    (fill-human-el driver (get-active-element driver) text opts)))
 

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -187,7 +187,7 @@
       (-> e/get-url
           (str/ends-with? "?login=1test2+A&password=&message=")
           is)))
-    (testing "fill active"
+  (testing "fill active"
     (doto *driver*
       (e/click :simple-input)
       (e/fill-active "MyLogin")
@@ -202,11 +202,11 @@
   (testing "fill active human"
     (doto *driver*
       (e/click :simple-input)
-      (e/fill-active-human "MyLogin2")
+      (e/fill-human-active "MyLogin2")
       (e/click :simple-password)
-      (e/fill-active-human "MyPassword2")
+      (e/fill-human-active "MyPassword2")
       (e/click :simple-textarea)
-      (e/fill-active-human "Some text 2")
+      (e/fill-human-active "Some text 2")
       (e/click :simple-submit)
       (e/when-safari (e/wait 3)))
     (is (str/ends-with? (e/get-url *driver*)


### PR DESCRIPTION
This fits in better with the naming conventions that Etaoin has adopted previously. Compare, for instance, fill-multi and fill-human-multi versus fill-active and fill-human-active.

Amendment to #629 

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
