### PR TITLE
`:no-doc` to `:private`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,8 @@ A release with an intentional breaking changes is marked with:
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
+** {issue}633[#633]: The `dispatch-driver` function is an implementation function and has been marked `:private`.
+** {issue}633[#633]: Duplicate definitions of `locator-xpath` and `locator-css` have been removed from the `etaoin.api` namespace. If you need these definitions, use the ones in `etaoin.query`.
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,8 +29,6 @@ A release with an intentional breaking changes is marked with:
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
-** {issue}633[#633]: The `dispatch-driver` function is an implementation function and has been marked `:private`.
-** {issue}633[#633]: Duplicate definitions of `locator-xpath` and `locator-css` have been removed from the `etaoin.api` namespace. If you need these definitions, use the ones in `etaoin.query`.
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -206,7 +206,7 @@
 ;; utils
 ;;
 
-(defn ^:no-doc dispatch-driver
+(defn- dispatch-driver
   "Returns the current driver's type. Used as dispatcher in
   multimethods."
   [driver & _]

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -169,9 +169,7 @@
 ;;
 ;; WebDriver defaults
 ;;
-(def ^:no-doc default-locator "xpath")
-(def ^:no-doc locator-xpath "xpath")
-(def ^:no-doc locator-css "css selector")
+(def ^:private default-locator query/locator-xpath)
 
 (def ^{:doc "WebDriver global option defaults"} defaults-global
   {:locator default-locator
@@ -2099,12 +2097,12 @@
 (defn use-xpath
   "Return new `driver` with default locator set to XPath."
   [driver]
-  (use-locator driver locator-xpath))
+  (use-locator driver query/locator-xpath))
 
 (defn use-css
   "Return new `driver` with default locator set to CSS."
   [driver]
-  (use-locator driver locator-css))
+  (use-locator driver query/locator-css))
 
 (defmacro ^:no-doc with-locator [driver locator & body]
   `(binding [~driver (assoc ~driver :locator ~locator)]
@@ -2113,13 +2111,13 @@
 (defmacro with-xpath
   "Execute `body` with default locator set to XPath."
   [driver & body]
-  `(with-locator ~driver locator-xpath
+  `(with-locator ~driver query/locator-xpath
      ~@body))
 
 (defmacro with-css
   "Execute `body` with default locator set to CSS."
   [driver & body]
-  `(with-locator ~driver locator-css
+  `(with-locator ~driver query/locator-css
      ~@body))
 
 ;;

--- a/src/etaoin/ide/impl/api.clj
+++ b/src/etaoin/ide/impl/api.clj
@@ -9,6 +9,7 @@
    [clojure.test :refer [is]]
    [clojure.tools.logging :as log]
    [etaoin.api :as e]
+   [etaoin.query :as query]
    [etaoin.impl.util :refer [defmethods]]
    [etaoin.keys :as k]))
 
@@ -433,7 +434,7 @@
 (defmethod run-command
   :storeXpathCount
   [driver {:keys [target value]} & [{vars :vars}]]
-  (let [cnt (count (e/find-elements* driver e/locator-xpath target))]
+  (let [cnt (count (e/find-elements* driver query/locator-xpath target))]
     (swap! vars assoc (str->var value) cnt)))
 
 (defmethod run-command

--- a/src/etaoin/query.clj
+++ b/src/etaoin/query.clj
@@ -10,7 +10,6 @@
 
 (set! *warn-on-reflection* true)
 
-;; todo duplicates with api.clj
 (def locator-xpath "xpath")
 (def locator-css "css selector")
 

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -227,21 +227,21 @@
         (is (= (f data) (e/get-element-value *driver* f)))))))
 
 (deftest test-unicode-above-bmp-input
-    ;; as of 2023-04-29 not supported on chrome and edge
-    ;; https://bugs.chromium.org/p/chromedriver/issues/detail?id=2269
-    (when-not (#{:chrome :edge} (e/dispatch-driver *driver*))
-      (let [data {:simple-input "😊🍂input🍃"
-                  :simple-password "🔆password☠️ "
-                  :simple-textarea "🎉🚀textarea👀☀️"}]
-        (testing "fill-multi"
-          (e/fill-multi *driver* data)
-          (doseq [f [:simple-input :simple-password :simple-textarea]]
-            (is (= (f data) (e/get-element-value *driver* f)))))
-        (testing "fill-human-multi"
-          (e/refresh *driver*)
-          (e/fill-human-multi *driver* data)
-          (doseq [f [:simple-input :simple-password :simple-textarea]]
-            (is (= (f data) (e/get-element-value *driver* f))))))))
+  ;; as of 2023-04-29 not supported on chrome and edge
+  ;; https://bugs.chromium.org/p/chromedriver/issues/detail?id=2269
+  (e/when-not-drivers #{:chrome :edge} *driver*
+                      (let [data {:simple-input "😊🍂input🍃"
+                                  :simple-password "🔆password☠️ "
+                                  :simple-textarea "🎉🚀textarea👀☀️"}]
+                        (testing "fill-multi"
+                          (e/fill-multi *driver* data)
+                          (doseq [f [:simple-input :simple-password :simple-textarea]]
+                            (is (= (f data) (e/get-element-value *driver* f)))))
+                        (testing "fill-human-multi"
+                          (e/refresh *driver*)
+                          (e/fill-human-multi *driver* data)
+                          (doseq [f [:simple-input :simple-password :simple-textarea]]
+                            (is (= (f data) (e/get-element-value *driver* f))))))))
 
 (deftest test-clear
   (testing "simple clear"


### PR DESCRIPTION
Closes #633 

It turns out that there isn't much low hanging fruit to move things from `:no-doc` to `:private`. There are just too many niggling dependencies between various macros in `etaoin.api` and other functions in other namespaces. While this could be done easily enough by moving implementation-related functions into an implementation namespace, that would be a more drastic change. So, not wanting to break our pick on this, we're going to leave it here.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
