### PR TITLE
Make vector arg to fill-multi/fill-human-multi fill in order

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,13 +22,13 @@ A release with an intentional breaking changes is marked with:
 * Changes
 ** {issue}559[#559]: Create `query-from` and `query-all-from` as replacements for `child` and `children`. Rewrite logic such that `q` parameter allows for vector syntax similar to `query` and `query-all`. Deprecate `child` and `children`. ({person}dgr[@dgr])
 ** {issue}559[#559]: Make `get-active-element` a public API. This was previously private. ({person}dgr[@dgr])
+** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
 ** {issue}620[#620]: Get stricter when unwrapping elements. ({person}dgr[@dgr])
 ** {issue}629[#629]: Added `fill-human-active` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
+** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
 ** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
-** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
-** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,13 +22,13 @@ A release with an intentional breaking changes is marked with:
 * Changes
 ** {issue}559[#559]: Create `query-from` and `query-all-from` as replacements for `child` and `children`. Rewrite logic such that `q` parameter allows for vector syntax similar to `query` and `query-all`. Deprecate `child` and `children`. ({person}dgr[@dgr])
 ** {issue}559[#559]: Make `get-active-element` a public API. This was previously private. ({person}dgr[@dgr])
-** {issue}629[#629]: Added `fill-human-active` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
 ** {issue}620[#620]: Get stricter when unwrapping elements. ({person}dgr[@dgr])
+** {issue}629[#629]: Added `fill-human-active` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
+** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
 ** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
 * Docs
 ** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
-** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,7 +27,6 @@ A release with an intentional breaking changes is marked with:
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
 ** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
-* Docs
 ** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ A release with an intentional breaking changes is marked with:
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
+** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,12 +24,12 @@ A release with an intentional breaking changes is marked with:
 ** {issue}559[#559]: Make `get-active-element` a public API. This was previously private. ({person}dgr[@dgr])
 ** {issue}629[#629]: Added `fill-human-active` as a convenience function that fills the currently active input using `fill-human-el`. ({person}dgr[@dgr])
 ** {issue}620[#620]: Get stricter when unwrapping elements. ({person}dgr[@dgr])
+** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
+** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
 * Docs
 ** {issue}559[#559]: Deprecate use of `:active` with `query` and other APIs that use `query` under the hood. ({person}dgr[@dgr])
 ** {issue}642[#642]: Add `driver-type` to retrieve driver type keyword. ({person}dgr[@dgr])
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
-** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
-** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2745,8 +2745,10 @@
   "Have `driver` fill multiple inputs via `q-text`.
 
   `q-text` can be:
-  - a map of `{q1 \"text1\" q2 \"text2\" ...}`
-  - a vector of `[q1 \"text1\" q2 \"text2\" ...]`
+  - a map of `{q1 \"text1\" q2 \"text2\" ...}`. There are no guarantees 
+    about the order in which fields are filled.
+  - a vector of `[q1 \"text1\" q2 \"text2\" ...]`. The fields are filled 
+    in the order the fields are listed in the vector.
 
   See [[query]] for details on `q`s."
   [driver q-text]
@@ -2756,7 +2758,12 @@
       (fill driver q text))
 
     (vector? q-text)
-    (recur driver (apply hash-map q-text))
+    (if (even? (count q-text))
+      (doseq [[q text] (partition 2 q-text)]
+        (fill driver q text))
+      (throw+ {:type    :etaoin/argument
+               :message "Vector q-text must have even length"
+               :arg     q-text}))
 
     :else (throw+ {:type    :etaoin/argument
                    :message "Wrong argument type"
@@ -2811,8 +2818,10 @@
   "Have `driver` fill multiple elements as if it were a real human being via `q-text` using `opts`.
 
   `q-text` can be:
-  - a map of `{q1 \"text1\" q2 \"text2\" ...}`
-  - a vector of `[q1 \"text1\" q2 \"text2\" ...]`
+  - a map of `{q1 \"text1\" q2 \"text2\" ...}`. There are no guarantees 
+    about the order in which fields are filled.
+  - a vector of `[q1 \"text1\" q2 \"text2\" ...]`. The fields are filled 
+    in the order the fields are listed in the vector.
 
   See [[query]] for details on `q`s.
 
@@ -2825,7 +2834,12 @@
        (fill-human driver q text opts))
 
      (vector? q-text)
-     (recur driver (apply hash-map q-text) opts)
+     (if (even? (count q-text))
+       (doseq [[q text] (partition 2 q-text)]
+         (fill driver q text))
+       (throw+ {:type    :etaoin/argument
+                :message "Vector q-text must have even length"
+                :arg     q-text}))
 
      :else (throw+ {:type    :etaoin/argument
                     :message "Wrong argument type"


### PR DESCRIPTION
Previously, if the user supplied a vector argument to fill-multi or fill-human-multi, Etaoin would convert the vector to a map, then convert the map to a sequence of MapEntry pairs, and use those to fill multiple fields. Unfortunately, this threw away all the ordering information in the vector. This change processes the vector as a sequence of partitioned pairs and thereby keeps the order intact.

Closes #649 

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
