### PR TITLE
Make `set-<xyz>-timeout` more resilient to non-integer timeout values

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ A release with an intentional breaking changes is marked with:
 ** {issue}644[#644]: Deprecate `when-predicate` and `when-not-predicate` macros. See docstrings for guidance on alternatives. These will may be removed from the API at the next release that contains breaking changes. ({person}dgr[@dgr])
 ** {issue}647[#647]: Fix logic bug in `intersects?`. Added tests to test suite. ({person}dgr[@dgr])
 ** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
+** {issue}657[#657]: Make `set-<xyz>-timeout` functions resilient to reasonable non-integer timeouts (e.g., rationals, doubles, etc.). ({person}dgr[@dgr])
 
 == v1.1.41 [minor breaking] - 2024-08-14 [[v1.1.41]]
 

--- a/src/etaoin/impl/util.clj
+++ b/src/etaoin/impl/util.clj
@@ -26,7 +26,7 @@
      (defmethod ~multifn dispatch-val# ~@fn-tail)))
 
 (defn sec->ms [sec]
-  (* sec 1000))
+  (long (* sec 1000)))
 
 (defn ms->sec [ms]
   (/ ms 1000))

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -1094,19 +1094,27 @@
                              {:class :inside} {:tag :span}])))))
 
 (deftest test-timeouts
-  (let [timeouts {:implicit 32134
-                  :script 78921
-                  :pageLoad 98765}]
-    (e/set-timeouts *driver* timeouts)
-    (is (= timeouts (e/get-timeouts *driver*)))
-    (e/set-page-load-timeout *driver* 987)
-    (e/set-implicit-timeout *driver* 876)
-    (e/set-script-timeout *driver* 765)
-    (is (= 987 (e/get-page-load-timeout *driver*)))
-    (is (= 876 (e/get-implicit-timeout *driver*)))
-    (is (= 765 (e/get-script-timeout *driver*)))
-    (is (= {:pageLoad 987000 :implicit 876000 :script 765000}
-           (e/get-timeouts *driver*)))))
+  (testing "basic timeout tests"
+    (let [timeouts {:implicit 32134
+                    :script 78921
+                    :pageLoad 98765}]
+      (e/set-timeouts *driver* timeouts)
+      (is (= timeouts (e/get-timeouts *driver*)))
+      (e/set-page-load-timeout *driver* 987)
+      (e/set-implicit-timeout *driver* 876)
+      (e/set-script-timeout *driver* 765)
+      (is (= 987 (e/get-page-load-timeout *driver*)))
+      (is (= 876 (e/get-implicit-timeout *driver*)))
+      (is (= 765 (e/get-script-timeout *driver*)))
+      (is (= {:pageLoad 987000 :implicit 876000 :script 765000}
+             (e/get-timeouts *driver*)))))
+  (testing "non-integer timeout values"
+    ;; These should not throw. If they do, the test runner will record
+    ;; a test failure.
+    (is (do (e/set-page-load-timeout *driver* 1.33333)
+            true))
+    (is (do (e/set-page-load-timeout *driver* 100/3)
+            true))))
 
 (comment
   ;; start test server


### PR DESCRIPTION
Closes #657 

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
