### PR TITLE
Throw a more accurate exception when query vector is empty

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ A release with an intentional breaking changes is marked with:
 ** {issue}649[#649]: When supplied a vector argument for `q-text`, `fill-multi` and `fill-human-multi` now fill fields in the order that fields appear in the vector. Previously, the order was not guaranteed. ({person}dgr[@dgr])
 ** {issue}657[#657]: Make `set-<xyz>-timeout` functions resilient to reasonable non-integer timeouts (e.g., rationals, doubles, etc.). ({person}dgr[@dgr])
 ** {issue}661[#661]: Fix `:fn/enabled`. ({person}dgr[@dgr])
+** {issue}663[#663]: `query` throws a more accurate exception with a more accurate error message when provided with an empty query vector. ({person}dgr[@dgr])
 * Docs
 ** {issue}656[#656]: Correctly describe behavior when query's parameter is a string. The User Guide and `query` doc strings say that a string passed to `query` is interpreted as an XPath expression. In fact, `query` interprets this as either XPath or CSS depending on the setting of the driver's `:locator` parameter, which can be changed. ({person}dgr[@dgr])
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -636,7 +636,11 @@
      (get-active-element driver)
 
      (vector? q)
-     (apply query driver q)
+     (if (empty? q)
+       (throw+ {:type :etaoin/argument
+                :message "Vector query must be non-empty"
+                :q q})
+       (apply query driver q))
 
      :else
      (let [[loc term] (query/expand driver q)]


### PR DESCRIPTION
Closes #663 

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [ ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address.  Not yet.

- [ ] This PR contains test(s) to protect against future regressions. Not currently, but these are coming in a larger PR dealing with test coverage.

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
