### PR TITLE
Issues 671 and 672

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,8 @@ A release with an intentional breaking changes is marked with:
 ** {issue}668[#668]: Throw an exception for unknown `:fn/*` keywords in map queries.
 * Docs
 ** {issue}656[#656]: Correctly describe behavior when query's parameter is a string. The User Guide and `query` doc strings say that a string passed to `query` is interpreted as an XPath expression. In fact, `query` interprets this as either XPath or CSS depending on the setting of the driver's `:locator` parameter, which can be changed. ({person}dgr[@dgr])
+** {issue}671[#671]: The `query` function now supports sequentials of all types (vectors, lists, seqs, etc.) with the same behavior as the previous vector-only syntax. ({person}dgr[@dgr])
+** {issue}672[#672]: Queries support hierarchical arrangements of sequences (sequences in sequences), which are flattened into a single sequence before query traversal. ({person}dgr[@dgr])
 * Quality
 ** {issue}640[#640]: Significantly improved test coverage. ({person}dgr[@dgr])
 

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -728,10 +728,10 @@ Here are some examples of the map syntax:
 ;; => true
 ----
 
-=== Vector Syntax Queries
+=== Sequential Queries
 
-A query can be a vector of any valid query expressions.
-For vector queries, every expression matches the output from the previous expression.
+A query can be a sequential collection (e.g., vectors, lists, seqs, etc.) of any valid query expressions, including other sequential collections.
+For sequential queries, every expression matches the output from the previous expression.
 
 A simple, somewhat contrived, example:
 
@@ -757,6 +757,29 @@ TIP: Reminder: the leading dot in an XPath expression means starting at the curr
 ;; our sample page shows link clicks, did it work?
 (e/get-element-text driver :clicked)
 ;; => "link 2 (active)"
+----
+
+You can also create a query from multiple pieces and pull them together by wrapping them in a sequence.
+For instance, you might have a common prefix in the query that leads to a particular component in the DOM tree and you want to use that repeatedly in multiple queries.
+
+[source,clojure]
+----
+;; first we define our prefix
+(def prefix [{:class :some-links} {:tag :ul}])
+;; now use it in a query
+;; this query structure is flattened to
+;; [{:class :some-links} {:tag :ul} {:tag :a}]
+(e/get-element-text driver [prefix {:tag :a}])
+;; => "link 1"
+----
+
+You can also create portions of the query structure using other sequence functions and leave it to `query` to flatten everything for you.
+
+[source,clojure]
+----
+(e/get-element-text driver [{:class :some-links}
+                            (filter identity [{:tag :ul} nil {:tag :a} nil])])
+;; => "link 1"
 ----
 
 === Advanced Queries

--- a/env/test/resources/static/test.html
+++ b/env/test/resources/static/test.html
@@ -215,13 +215,13 @@
         <h3>Find multiple elements nested</h3>
 
         <div id="find-elements-nested">
-            <div class="nested">
-                <div class="target">1</div>
-                <div class="target">2</div>
+            <div id="find-elements-nested-1" class="nested">
+                <div id="find-elements-nested-2" class="target">1</div>
+                <div id="find-elements-nested-3" class="target">2</div>
             </div>
-            <div class="nested">
-                <div class="target">3</div>
-                <div class="target">4</div>
+            <div id="find-elements-nested-4" class="nested">
+                <div id="find-elements-nested-5" class="target">3</div>
+                <div id="find-elements-nested-6" class="target">4</div>
             </div>
         </div>
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -614,14 +614,26 @@
    - any other map is converted to an XPath expression:
      - `{:tag :div}`
      - is equivalent to XPath: `\".//div\"`
-  - multiple of the above (wrapped in a vector or not).
+  - multiple of the above (wrapped in a sequential -- vector, list, seq -- or not).
     The result of each search anchors the search for the next,
     effectively providing a path through the DOM (though you do not
     have to specify each and every point in the path).
     - `{:tag :div} \".//input[@id='uname']\"`
     - `[{:tag :div} \".//input[@id='uname']\"]`
+    - `'({:tag :div} \".//input[@id='uname']\")`
     Returns the final element's unique identifier, or throws if any element
-    is not found.
+    along the path is not found.
+
+  - Note that sequences of sequences of arbitrary hierarchy are also
+  supported. Before traversing the path, `query` flattens the
+  hierarchy into a single linear sequence. This can allow for
+  sub-paths within the DOM to be stored in variables and simply
+  included in the path vector.
+    - e.g., `[[:id1 :id2 ] [ :id3 :id4 ]]` is flattened to
+       `[:id1 :id2 :id3 :id4]`.
+    - If `prefix` is bound to `[:id1 :id2]`, then Clojure will convert
+      `[prefix :id3 :id4]` to `[[:id1 :id2] :id3 :id4]` and `query`
+      will then flatten this to `[:id1 :id2 :id3 :id4]`.
 
   See [Selecting Elements](/doc/01-user-guide.adoc#querying) for more details.
 

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -635,10 +635,10 @@
      (= q :active)
      (get-active-element driver)
 
-     (vector? q)
+     (sequential? q)
      (if (empty? q)
        (throw+ {:type :etaoin/argument
-                :message "Vector query must be non-empty"
+                :message "Queries must be non-empty"
                 :q q})
        (apply query driver q))
 
@@ -647,10 +647,16 @@
        (find-element* driver loc term))))
 
   ([driver q & more]
-   (letfn [(folder [el q]
-             (let [[loc term] (query/expand driver q)]
-               (find-element-from* driver el loc term)))]
-     (reduce folder (query driver q) more))))
+   (let [[q & more :as full-q] (flatten (cons q more))]
+     (if (empty? full-q)
+       (throw+ {:type :etaoin/argument
+                :message "Queries must be non-empty"
+                :q full-q})
+       (reduce (fn [el q]
+                 (let [[loc term] (query/expand driver q)]
+                   (find-element-from* driver el loc term)))
+               (query driver q)
+               more)))))
 
 (defn query-all
   "Use `driver` to return a vector of all elements on current page matching `q`.


### PR DESCRIPTION
Closes #671 
Closes #672

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [ ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address.  Not yet. I waited for a couple of days after discussing both #671 and #672 last week. I started to code up what I agreed to (throw better errors), but because of the way that `query` is coded, it rapidly became a bit of a mess. I stepped back and asked myself, "Is this the Right Answer?" I didn't feel like it. So, I left that alone and coded up what I had proposed. The code fell into place very naturally and so I kept going, adding regression tests, updating the User Guide, and ultimately the CHANGELOG. So, here it is. In this PR, `query` supports arbitrary sequentials, not just vectors. This means vectors, lists, seqs of all sorts, etc. Also, it supports an arbitrary hierarchy of sequentials which are then `flatten`-ed before the traversal starts. This allows for easy storage of partial paths (e.g., path prefixes) in variables which can simply be added to a sequential query as well as generation of parts of the path programmatically when the result of that generation is something like a lazy-seq (e.g., something returned by all the lazy collection routines).

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
