### PR TITLE
ci & dev & lib: bump deps

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,7 +9,8 @@
  {:macroexpand
   {etaoin.impl.util/defmethods etaoin.impl.util/defmethods
    etaoin.impl.util/with-tmp-file etaoin.impl.util/with-tmp-file}}
- :linters {:deprecated-var
+ :linters {:redundant-ignore {:level :off}
+           :deprecated-var
            {:exclude {etaoin.api/child {:namespaces [etaoin.api-test]}
                       etaoin.api/children {:namespaces [etaoin.api-test]}}}
            :unresolved-symbol

--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,1 +1,5 @@
-{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}
+{:hooks
+ {:analyze-call
+  {taoensso.encore/defalias    taoensso.encore/defalias
+   taoensso.encore/defn-cached taoensso.encore/defn-cached
+   taoensso.encore/defonce     taoensso.encore/defonce}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,16 +1,51 @@
 (ns taoensso.encore
+  "I don't personally use clj-kondo, so these hooks are
+  kindly authored and maintained by contributors.
+  PRs very welcome! - Peter Taoussanis"
+  (:refer-clojure :exclude [defonce])
   (:require
    [clj-kondo.hooks-api :as hooks]))
 
-(defn defalias [{:keys [node]}]
+(defn defalias
+  [{:keys [node]}]
   (let [[sym-raw src-raw] (rest (:children node))
-        src (if src-raw src-raw sym-raw)
-        sym (if src-raw
-              sym-raw
-              (symbol (name (hooks/sexpr src))))]
-    {:node (with-meta
-             (hooks/list-node
-               [(hooks/token-node 'def)
-                (hooks/token-node (hooks/sexpr sym))
-                (hooks/token-node (hooks/sexpr src))])
-             (meta src))}))
+        src (or src-raw sym-raw)
+        sym (if src-raw sym-raw (symbol (name (hooks/sexpr src))))]
+    {:node
+     (with-meta
+       (hooks/list-node
+         [(hooks/token-node 'def)
+          (hooks/token-node (hooks/sexpr sym))
+          (hooks/token-node (hooks/sexpr src))])
+       (meta src))}))
+
+(defn defn-cached
+  [{:keys [node]}]
+  (let [[sym _opts binding-vec & body] (rest (:children node))]
+    {:node
+     (hooks/list-node
+       (list
+         (hooks/token-node 'def)
+         sym
+         (hooks/list-node
+           (list*
+             (hooks/token-node 'fn)
+             binding-vec
+             body))))}))
+
+(defn defonce
+  [{:keys [node]}]
+  ;; args = [sym doc-string? attr-map? init-expr]
+  (let [[sym & args] (rest (:children node))
+        [doc-string args]    (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next  args)] [nil        args])
+        [attr-map init-expr] (if (and (hooks/map-node?    (first args)) (next args)) [(hooks/sexpr (first args)) (fnext args)] [nil (first args)])
+
+        attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
+        sym+meta (if attr-map (with-meta sym attr-map) sym)
+        rewritten
+        (hooks/list-node
+          [(hooks/token-node 'clojure.core/defonce)
+           sym+meta
+           init-expr])]
+
+    {:node rewritten}))

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         java-version: '21'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@12.5
+      uses: DeLaGuardo/setup-clojure@13.0
       with:
         bb: 'latest'
         cli: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@12.5
+      uses: DeLaGuardo/setup-clojure@13.0
       with:
         bb: 'latest'
 
@@ -147,7 +147,7 @@ jobs:
         java-version: ${{ matrix.jdk-version }}
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@12.5
+      uses: DeLaGuardo/setup-clojure@13.0
       with:
         bb: 'latest'
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,8 @@ A release with an intentional breaking changes is marked with:
 == Unreleased
 
 * Changes
+** Bumped deps.
+({lread})
 ** {issue}676[#676]: Fix new driver creation so that it sidesteps some underlying Firefox race conditions and improves CI test stability. ({person}dgr[@dgr])
 ** {issue}679[#679]: Add `new-window` function that exposes WebDriver's New Window endpoint. ({person}dgr[@dgr])
 ** {issue}682[#682]: Fixed a bug in `fill-human-multi` to correctly call `fill-human` rather than `fill`. ({person}dgr[@dgr])

--- a/bb.edn
+++ b/bb.edn
@@ -1,13 +1,13 @@
 {:min-bb-version "0.8.2"
  :paths ["script" "build"]
  :deps {doric/doric {:mvn/version "0.9.0"}
-        org.clj-commons/pretty {:mvn/version "3.0.0"}
+        org.clj-commons/pretty {:mvn/version "3.2.0"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
-        org.babashka/http-server {:mvn/version "0.1.12"}
+        org.babashka/http-server {:mvn/version "0.1.13"}
         wevre/natural-compare {:mvn/version "0.0.10"}
-        io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}}
+        io.github.babashka/neil {:git/tag "v0.3.68" :git/sha "78ffab1"}}
  :tasks
  {;; setup
   :requires ([babashka.classpath :as cp]

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.10.3"} ;; min clojure version
         babashka/fs {:mvn/version "0.5.22"}
         babashka/process {:mvn/version "0.5.22"}
-        org.babashka/http-client {:mvn/version "0.4.20"}
+        org.babashka/http-client {:mvn/version "0.4.22"}
         slingshot/slingshot {:mvn/version "0.12.2"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         org.clojure/tools.cli {:mvn/version "1.1.230"}
@@ -17,11 +17,11 @@
                    :github-coords clj-commons/etaoin}}
 
   :1.11 {:replace-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
-  :1.12 {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0-rc1"}}}
+  :1.12 {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}
   :debug {:extra-paths ["env/dev/resources"]}
   :test {:extra-paths ["test" "env/test/resources" "build"]
          :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                      org.babashka/cli {:mvn/version "0.8.60"}
+                      org.babashka/cli {:mvn/version "0.8.61"}
                       ch.qos.logback/logback-classic {:mvn/version "1.3.14"}
                       ;; for http-client which uses apache http client 4.x which uses commons logging
                       org.slf4j/jcl-over-slf4j {:mvn/version "2.0.16"}}
@@ -33,7 +33,7 @@
   :script {:extra-paths ["script"]}
 
   ;; test-doc-blocks - gen tests
-  :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.11.4"}
+  :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                                    com.github.lread/test-doc-blocks  {:mvn/version "1.1.20"}}
                     :replace-paths []
                     :ns-default lread.test-doc-blocks
@@ -41,7 +41,7 @@
 
   ;; test-doc-blocks - run tests
   ;; usage: test:test-docs
-  :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+  :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
               :extra-paths ["target/test-doc-blocks/test"]
               :exec-fn cognitect.test-runner.api/test
               :exec-args {:dirs ["target/test-doc-blocks/test"]}
@@ -51,8 +51,8 @@
               :main-opts ["-m" "babashka.cli.exec"]}
 
   :clofidence {:classpath-overrides {org.clojure/clojure nil}
-               :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.4"}
-                            com.github.flow-storm/clofidence {:mvn/version "0.3.1"}}
+               :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-1"}
+                            com.github.flow-storm/clofidence {:mvn/version "0.4.0"}}
                :exec-fn clofidence.main/run
                :exec-args {:report-name "Etaoin Test Coverage"
                            :output-folder "target/clofidence"
@@ -61,7 +61,7 @@
                :jvm-opts ["-Dclojure.storm.instrumentOnlyPrefixes=etaoin"]}
 
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.01"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.11.14"}}
               :main-opts ["-m" "clj-kondo.main"]}
 
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
@@ -80,8 +80,8 @@
   ;; caused by, I think, conflicting maven deps
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}}
 
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1206"}
-                          org.clojure/clojure {:mvn/version "1.11.1"}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.11.1250"}
+                          org.clojure/clojure {:mvn/version "1.12.0"}
                           org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
                           }
              :main-opts ["-m" "antq.core"
@@ -90,9 +90,9 @@
                          ]}
 
   :repl/cider
-  {:extra-deps {org.clojure/clojure {:mvn/version "1.11.4"}
+  {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                 nrepl/nrepl                {:mvn/version "1.3.0"}
-                cider/cider-nrepl          {:mvn/version "0.49.2"}
+                cider/cider-nrepl          {:mvn/version "0.50.2"}
                 refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
    :main-opts  ["-m" "nrepl.cmdline"

--- a/script/docker_install.clj
+++ b/script/docker_install.clj
@@ -58,7 +58,7 @@
   "`id` is also name of executable"
   [{:keys [id version url]}]
   (status/line :head "Installing %s %s" id version)
-  (let [dl-file (str "/tmp/%s.zip")
+  (let [dl-file "/tmp/chrome-installer.zip"
         install-dir (str "/opt/" id "-" version)]
     (fs/create-dirs install-dir)
     (status/line :head "%s: downloading: %s" id url)

--- a/script/publish.clj
+++ b/script/publish.clj
@@ -160,9 +160,9 @@
                  ;; followed by any attributes
                  "$1"
                   ;; followed by datestamp
-                 (str " - " (yyyy-mm-dd-now-utc))
+                 " - " (yyyy-mm-dd-now-utc)
                   ;; followed by an AsciiDoc anchor for easy referencing
-                 (str " [[v" version  "]]")
+                 " [[v" version  "]]"
                   ;; followed by section content
                  "$2"
                   ;; followed by link to commit log

--- a/script/test_matrix.clj
+++ b/script/test_matrix.clj
@@ -41,12 +41,12 @@
    :desc (str "test-doc " os " jdk" jdk-version)} )
 
 (defn- github-actions-matrix []
-  (let [jdks ["11" "17" "21"]
+  (let [jdks ["11" "17" "21" "23"]
         oses ["ubuntu" "macos" "windows"]
         ide-browsers ["chrome" "firefox"]
         api-browsers ["chrome" "firefox" "edge" "safari"]
         platforms ["jvm" "bb"]
-        default-opts {:jdk-version "21"}]
+        default-opts {:jdk-version "21"}] ;; if only testing on one, test on latest LTS
     (->> (concat
            (for [os oses
                  platform platforms]

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -226,7 +226,7 @@
   (let [obj (get web-driver-obj identifier ::not-found)]
     (if (= obj ::not-found)
       (throw (ex-info (str "Could not find object tagged with " identifier
-                           " in " (str web-driver-obj))
+                           " in " web-driver-obj)
                       {:web-driver-obj web-driver-obj
                        :identifier identifier}))
       obj)))


### PR DESCRIPTION
Of note:
- Bumped lib dep babashka/http-client
- New clj-kondo linter founder redundant str calls! Cool! Fixed!
- Clj-kondo redundant-ignore (now on by default) might be amiss with regards to custom hook linters. It was thinking our test ignore for `:etaoin/empty-opts` could be removed. This is not the case, I'll follow up over at clj-kondo.
- Added jdk23 to CI mix.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
