### PR TITLE
test & ci: bump deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         java-version: '21'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@13.1
+      uses: DeLaGuardo/setup-clojure@13.2
       with:
         bb: 'latest'
         cli: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@13.1
+      uses: DeLaGuardo/setup-clojure@13.2
       with:
         bb: 'latest'
 
@@ -152,7 +152,7 @@ jobs:
         java-version: ${{ matrix.jdk-version }}
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@13.1
+      uses: DeLaGuardo/setup-clojure@13.2
       with:
         bb: 'latest'
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.8.2"
  :paths ["script" "build"]
  :deps {doric/doric {:mvn/version "0.9.0"}
-        org.clj-commons/pretty {:mvn/version "3.3.0"}
+        org.clj-commons/pretty {:mvn/version "3.3.1"}
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}

--- a/deps.edn
+++ b/deps.edn
@@ -22,9 +22,9 @@
   :test {:extra-paths ["test" "env/test/resources" "build"]
          :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                       org.babashka/cli {:mvn/version "0.8.62"}
-                      ch.qos.logback/logback-classic {:mvn/version "1.3.15"}
+                      ch.qos.logback/logback-classic {:mvn/version "1.5.18"}
                       ;; for http-client which uses apache http client 4.x which uses commons logging
-                      org.slf4j/jcl-over-slf4j {:mvn/version "2.0.16"}
+                      org.slf4j/jcl-over-slf4j {:mvn/version "2.0.17"}
                       ;; slingshot does not have a kondo config, grab kondo team provided config from here
                       io.github.clj-kondo/config-slingshot-slingshot {:mvn/version "1.0.0"}}
          :exec-fn test-shared/test
@@ -53,8 +53,8 @@
               :main-opts ["-m" "babashka.cli.exec"]}
 
   :clofidence {:classpath-overrides {org.clojure/clojure nil}
-               :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-2"}
-                            com.github.flow-storm/clofidence {:mvn/version "0.4.0"}}
+               :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.0-9"}
+                            com.github.flow-storm/clofidence {:mvn/version "0.4.1"}}
                :exec-fn clofidence.main/run
                :exec-args {:report-name "Etaoin Test Coverage"
                            :output-folder "target/clofidence"
@@ -63,7 +63,7 @@
                :jvm-opts ["-Dclojure.storm.instrumentOnlyPrefixes=etaoin"]}
 
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2025.01.16"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2025.02.20"}}
               :main-opts ["-m" "clj-kondo.main"]}
 
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
@@ -74,7 +74,7 @@
                                                :exclude-linters [:local-shadows-var]
                                                :ignored-faults {:deprecations {etaoin.api-test true}}}]}
 
-  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.6"}}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}}
           :extra-paths ["build"]
           :ns-default build}
 
@@ -82,19 +82,16 @@
   ;; caused by, I think, conflicting maven deps
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}}
 
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.11.1264"}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.11.1276"}
                           org.clojure/clojure {:mvn/version "1.12.0"}
-                          org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
+                          org.slf4j/slf4j-simple {:mvn/version "2.0.17"} ;; to rid ourselves of logger warnings
                           }
-             :main-opts ["-m" "antq.core"
-                         "--exclude=ch.qos.logback/logback-classic@1.4.x" ;; requires min jdk 11, we are currently jdk8 compatible
-                         "--exclude=ch.qos.logback/logback-classic@1.5.x" ;; requires min jdk 11, we are currently jdk8 compatible
-                         ]}
+             :main-opts ["-m" "antq.core"]}
 
   :repl/cider
   {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}
-                nrepl/nrepl                {:mvn/version "1.3.1"}
-                cider/cider-nrepl          {:mvn/version "0.52.0"}
+                nrepl/nrepl {:mvn/version "1.3.1"}
+                cider/cider-nrepl {:mvn/version "0.53.2"}
                 refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
    :main-opts  ["-m" "nrepl.cmdline"

--- a/script/test_matrix.clj
+++ b/script/test_matrix.clj
@@ -41,7 +41,7 @@
    :desc (str "test-doc " os " jdk" jdk-version)} )
 
 (defn- github-actions-matrix []
-  (let [jdks ["11" "17" "21" "23"]
+  (let [jdks ["11" "17" "21" "24"]
         oses ["ubuntu" "macos" "windows"]
         ide-browsers ["chrome" "firefox"]
         api-browsers ["chrome" "firefox" "edge" "safari"]


### PR DESCRIPTION
Of note:
- ci matrix bump of jdk23->jdk24
- noticed some hold-backs of deps due to jdk8 compat, but we are now jdk11+

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
