### PR TITLE
Don't swallow exceptions from parsing json

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,8 @@ A release with an intentional breaking changes is marked with:
 * Changes
 ** Bumped deps.
 ({lread})
+** {issue}696[#696]: Stop hiding json parse exceptions
+({lread})
 ** {issue}676[#676]: Fix new driver creation so that it sidesteps some underlying Firefox race conditions and improves CI test stability. ({person}dgr[@dgr])
 ** {issue}679[#679]: Add `new-window` function that exposes WebDriver's New Window endpoint. ({person}dgr[@dgr])
 ** {issue}682[#682]: Fixed a bug in `fill-human-multi` to correctly call `fill-human` rather than `fill`. ({person}dgr[@dgr])

--- a/src/etaoin/impl/client.clj
+++ b/src/etaoin/impl/client.clj
@@ -50,9 +50,7 @@
 
 (defn- parse-json [body]
   (let [body* (str/replace body #"Invalid Command Method -" "")]
-    (try
-      (json/parse-string body* true)
-      (catch Throwable _ body))))
+    (json/parse-string body* true)))
 
 (defn- error-response [body]
   (if (string? body)

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -3,6 +3,7 @@
    [babashka.fs :as fs]
    [babashka.process :as p]
    [cheshire.core :as json]
+   [cheshire.factory :as cheshire-factory]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -1332,6 +1333,16 @@
             true))
     (is (do (e/set-page-load-timeout *driver* 100/3)
             true))))
+
+(deftest test-json-parse-error
+  ;; output pdf should never be created, but just in case...
+  (let [out-pdf (-> (fs/create-temp-file {:prefix "print-page" :suffix "pdf"})
+                    fs/delete-on-exit)]
+    (is (thrown-with-msg?
+          Exception #"(?i)string.*exceeds.*512"
+          (binding [cheshire-factory/*json-factory* (cheshire-factory/make-json-factory
+                                                      {:max-input-string-length 512})]
+            (e/print-page *driver* out-pdf))))))
 
 (comment
   ;; start test server


### PR DESCRIPTION
When Etaoin failed parse a json webdriver response, it would swallow the exception. This lead to confusing "empty page" exceptions.

We now let the true json parse exception to flow through.

Closes #696

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
