### PR TITLE
ci: turf off verbose logging for some tests

### DIFF
--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -47,12 +47,21 @@
 
 (def default-opts
   {:chrome  {}
-   :firefox (cond-> {}
+   :firefox {}
+            #_
+            ;; I don't typically leave commented code in, but this might be nice to quickly turn
+            ;; back on for ci on windows someday
+            (cond-> {}
               ;; add logging for typically flaky CI scenario
               (and (ci?) (fs/windows?)) (merge {:log-stdout :inherit
                                                 :log-stderr :inherit
                                                 :driver-log-level "info"}))
-   :safari (cond-> {}
+
+   :safari {}
+           #_
+           ;; I don't typically leave commented code in, but this might be nice to quickly turn
+           ;; back on for ci someday, there are no log levels, it is extremely verbose or off
+           (cond-> {}
              ;; add logging for kind of flaky CI scenario (maybe we'll answer why we need
              ;; to retry launching safaridriver automatically)
              (ci?) (merge {:log-stdout :inherit


### PR DESCRIPTION
While diagnosing some safari on macos and firefox on windows I had turned on logging for ci.

We can turn it back on if need be, but for now it is more noisy than helpful. And I suspect, might have been slowing ci testing for safari.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
