### PR TITLE
Allow for large json strings in webdriver response

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,8 @@ A release with an intentional breaking changes is marked with:
 * Changes
 ** Bumped deps.
 ({lread})
+** {issue}691[#691]: Allow for large json strings in webdriver responses
+({lread})
 ** {issue}696[#696]: Stop hiding json parse exceptions
 ({lread})
 ** {issue}676[#676]: Fix new driver creation so that it sidesteps some underlying Firefox race conditions and improves CI test stability. ({person}dgr[@dgr])


### PR DESCRIPTION
Etaoin uses cheshire which uses jackson.
Jackson implemented, for security reasons, processing limits. Starting with cheshire 6.0.0 these jackson limits are configurable.

The default json input string length for jackson is 20mb. This is small for Etaoin, a webdriver will return a base64 encoded pdf for a print page request.
We've bumped the json input string limit to ~2gb.

Closes #691

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [ ] This PR contains test(s) to protect against future regressions (the existing json parse error test should suffice)

- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
