### PR TITLE
test: fix sporadic fill human errors on macos edge

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1065,6 +1065,9 @@ For multiple inputs, use `fill-human-multi`
                             :pause-max 0.1})
 ----
 
+WARNING: The fill human functions can compete with browser form/input autocomplete and occassionally give unexpected results.
+We noticed this in our own tests for Microsoft Edge running on macOS.
+
 === Mouse Clicks
 
 The `click` function triggers the left mouse click on an element found by a query term:

--- a/env/test/resources/ide/test.side
+++ b/env/test/resources/ide/test.side
@@ -62,7 +62,7 @@
       "target": "id=simple-password",
       "targets": [
         ["id=simple-password", "id"],
-        ["name=password", "name"],
+        ["name=passphrase", "name"],
         ["css=#simple-password", "css:finder"],
         ["xpath=//input[@id='simple-password']", "xpath:attributes"],
         ["xpath=//form[@id='submit-test']/input[2]", "xpath:idRelative"],
@@ -76,7 +76,7 @@
       "target": "id=simple-password",
       "targets": [
         ["id=simple-password", "id"],
-        ["name=password", "name"],
+        ["name=passphrase", "name"],
         ["css=#simple-password", "css:finder"],
         ["xpath=//input[@id='simple-password']", "xpath:attributes"],
         ["xpath=//form[@id='submit-test']/input[2]", "xpath:idRelative"],
@@ -377,7 +377,7 @@
       "target": "id=simple-password",
       "targets": [
         ["id=simple-password", "id"],
-        ["name=password", "name"],
+        ["name=passphrase", "name"],
         ["css=#simple-password", "css:finder"],
         ["xpath=//input[@id='simple-password']", "xpath:attributes"],
         ["xpath=//form[@id='submit-test']/input[2]", "xpath:idRelative"],

--- a/env/test/resources/static/test.html
+++ b/env/test/resources/static/test.html
@@ -30,12 +30,13 @@
 
         <h3>Input section</h3>
         <div>
-            <form id="submit-test" method="GET">
+            <form id="submit-test" autocomplete="off" method="GET">
                 <label>Login</label>
                 <input id="simple-input" name="login" type="text"><br>
                 <label>Password</label>
+                <!-- name=password causes masking in github actions output, name=passphrase does not -->
                 <input id="simple-password"
-                       name="password" type="password"><br>
+                       name="passphrase" type="password"><br>
                 <label>Message</label>
                 <textarea id="simple-textarea"
                           name="message"></textarea><br>


### PR DESCRIPTION
On this os/browser, autocomplete was sometimes interfering with fill human enough to cause test failures.

Resolve by adding `autocomplete="off"` to html test page.

Closes #646

Also:
- rename `password` in html input to `passphrase` to avoid github actions masking what it thinks is sensitive data on test failure
- refresh browser in `input-test` for each `testing` block for better isolation
- test helper fns `wait-url-change` and `reload-test-page` now take a `driver` arg instead of using `*driver*` for easier reuse in REPL testing.

Please complete and include the following checklist:

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).

- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. 

- [x] This PR contains test(s) to protect against future regressions

- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
