### PR TITLE
fix: dev: response status was always nil

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,8 @@ A release with an intentional breaking changes is marked with:
 == Unreleased
 
 * Changes
+** {issue}98[#98]: `etaoin.dev` now reports the HTTP status of a response.
+The status was read from the response headers, where DevTools does not put it, so the `[:response :status]` of every request returned by `get-requests`/`get-ajax`/`logs->requests` was always `nil`.
 ** Migrate to org.clj-commons/slingshot
 ** Bumped deps
 ({lread})

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1940,7 +1940,7 @@ The results will be different when you try this, but here's what I experienced:
 ;;       :User-Agent
 ;;       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
 ;;     :response
-;;     {:status nil,
+;;     {:status 200,
 ;;      :headers
 ;;      {:date "Sat, 04 Jun 2022 00:11:36 GMT",
 ;;       :x-xss-protection "0",
@@ -2004,7 +2004,7 @@ Since we're mostly interested in AJAX requests, there is a function `get-ajax` t
 ;;    :User-Agent
 ;;    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
 ;;  :response
-;;  {:status nil,
+;;  {:status 200,
 ;;   :headers
 ;;   {:bfcache-opt-in "unload",
 ;;    :date "Sat, 04 Jun 2022 04:10:35 GMT",
@@ -2126,7 +2126,7 @@ Unlike `get-requests` and `get-ajax`, they are pure functions and won't flush an
 ;;       :User-Agent
 ;;       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"}},
 ;;     :response
-;;     {:status nil,
+;;     {:status 204,
 ;;      :headers
 ;;      {:alt-svc
 ;;       "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",

--- a/src/etaoin/dev.clj
+++ b/src/etaoin/dev.clj
@@ -8,10 +8,15 @@
 (set! *warn-on-reflection* true)
 
 (defn- try-parse-int
-  [line]
-  (try (Integer/parseInt line)
-       (catch Exception _e
-         line)))
+  "Return `v` as an int when it is a string that parses as one, else `v` unchanged.
+
+  DevTools reports the response status as a number, but we stay lenient about it."
+  [v]
+  (if (string? v)
+    (try (Integer/parseInt v)
+         (catch Exception _e
+           v))
+    v))
 
 (defn- parse-json
   [string]
@@ -81,9 +86,8 @@
                          :headers headers}))
 
       :network/responsereceived
-      (let [{:keys [response]}                         params
-            {:keys [headers mimeType remoteIPAddress]} response
-            {:keys [status]}                           headers]
+      (let [{:keys [response]}                                params
+            {:keys [status headers mimeType remoteIPAddress]} response]
         (assoc acc
                :state 2
                :response {:status    (try-parse-int status)

--- a/test/etaoin/unit/dev_test.clj
+++ b/test/etaoin/unit/dev_test.clj
@@ -1,0 +1,159 @@
+(ns etaoin.unit.dev-test
+  "Unit tests for `etaoin.dev` performance log parsing.
+
+  These are hermetic: they feed in Chrome DevTools performance log entries of the shape
+  `etaoin.dev/get-performance-logs` returns, so no browser is required."
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is testing]]
+   [etaoin.dev :as dev]
+   [etaoin.test-report]))
+
+;; ---------------------------------------------------------------------------
+;; helpers to build performance log entries as Chrome emits them
+
+(defn- log-entry
+  "Build a performance log entry carrying DevTools `method` and `params`.
+
+  Chrome hands us `:message` as a JSON string, which is what `etaoin.dev` parses."
+  [method params]
+  {:level     :info
+   :timestamp 1654315896000
+   :message   (json/generate-string {:message {:method method :params params}
+                                     :webview "9EB2E2C4E7C3D0C48D8E8D2B6E1F0A11"})})
+
+(defn- process
+  "Run raw log entries through the same private parsing step `get-performance-logs` uses."
+  [entries]
+  (mapv #'dev/process-log entries))
+
+(defn- request-sent [request-id {:keys [url method type has-post-data headers]}]
+  (log-entry "Network.requestWillBeSent"
+             {:requestId  request-id
+              :documentURL "https://www.google.com/"
+              :type       (or type "Image")
+              :request    {:url         url
+                           :method      (or method "GET")
+                           :headers     (or headers {:Referer "https://www.google.com/"})
+                           :hasPostData has-post-data}}))
+
+(defn- response-received [request-id {:keys [status headers mime remote-ip type]}]
+  (log-entry "Network.responseReceived"
+             {:requestId request-id
+              :type      (or type "Image")
+              :response  {:url             "https://www.google.com/images/x.webp"
+                          :status          status
+                          :statusText      ""
+                          :headers         (or headers {:content-type "image/webp"
+                                                        :content-length "660"})
+                          :mimeType        (or mime "image/webp")
+                          :remoteIPAddress (or remote-ip "142.250.185.68")
+                          :remotePort      443}}))
+
+(defn- loading-finished [request-id]
+  (log-entry "Network.loadingFinished"
+             {:requestId request-id :encodedDataLength 660}))
+
+(defn- loading-failed [request-id]
+  (log-entry "Network.loadingFailed"
+             {:requestId request-id :errorText "net::ERR_ABORTED" :canceled false}))
+
+(defn- request-by-id [requests id]
+  (some #(when (= id (:id %)) %) requests))
+
+;; ---------------------------------------------------------------------------
+
+(deftest response-status-is-read-from-the-response
+  (testing "status comes from the DevTools response object"
+    ;; Regression test for #98: status was previously destructured from the response
+    ;; *headers*, where DevTools never puts it, so :status was always nil.
+    (let [requests (dev/logs->requests
+                    (process [(request-sent "1.1" {:url "https://www.google.com/images/x.webp"})
+                              (response-received "1.1" {:status 200})
+                              (loading-finished "1.1")]))
+          request  (request-by-id requests "1.1")]
+      (is (= 1 (count requests)))
+      (is (= 200 (-> request :response :status)))))
+
+  (testing "status is not taken from the response headers"
+    ;; A header literally named `status` must not win over the real response status.
+    (let [requests (dev/logs->requests
+                    (process [(request-sent "2.1" {:url "https://example.org/"})
+                              (response-received "2.1" {:status 404
+                                                        :headers {:status "599"
+                                                                  :content-type "text/html"}})
+                              (loading-finished "2.1")]))
+          request  (request-by-id requests "2.1")]
+      (is (= 404 (-> request :response :status)))))
+
+  (testing "a string status is parsed to an int, anything unparseable is passed through"
+    (let [status-of (fn [id raw]
+                      (-> (dev/logs->requests
+                           (process [(request-sent id {:url "https://example.org/"})
+                                     (response-received id {:status raw})
+                                     (loading-finished id)]))
+                          (request-by-id id)
+                          :response
+                          :status))]
+      (is (= 301 (status-of "3.1" "301")))
+      (is (= "nonsense" (status-of "3.2" "nonsense")))
+      (is (nil? (status-of "3.3" nil))))))
+
+(deftest request-is-assembled-across-log-entries
+  (testing "a full request/response/finish sequence produces the documented shape"
+    (let [requests (dev/logs->requests
+                    (process [(request-sent "4.1" {:url "https://www.google.com/images/x.webp"
+                                                   :method "GET"
+                                                   :type "Image"
+                                                   :has-post-data false})
+                              (response-received "4.1" {:status 200
+                                                        :mime "image/webp"
+                                                        :remote-ip "142.250.185.68"})
+                              (loading-finished "4.1")]))
+          request  (request-by-id requests "4.1")]
+      (is (= {:state      4
+              :id         "4.1"
+              :type       :image
+              :xhr?       false
+              :url        "https://www.google.com/images/x.webp"
+              :with-data? false
+              :done?      true}
+             (dissoc request :request :response)))
+      (is (= {:method :get
+              :headers {:Referer "https://www.google.com/"}}
+             (:request request)))
+      (is (= {:status    200
+              :headers   {:content-type "image/webp" :content-length "660"}
+              :mime      "image/webp"
+              :remote-ip "142.250.185.68"}
+             (:response request)))
+      (is (dev/request-done? request))
+      (is (not (dev/request-failed? request)))
+      (is (dev/request-success? request)))))
+
+(deftest failed-request-is-reported-as-failed
+  (let [requests (dev/logs->requests
+                  (process [(request-sent "5.1" {:url "https://example.org/gone" :type "XHR"})
+                            (loading-failed "5.1")]))
+        request  (request-by-id requests "5.1")]
+    (is (dev/request-failed? request))
+    (is (not (dev/request-done? request)))
+    (is (not (dev/request-success? request)))))
+
+(deftest ajax-requests-are-selected-by-type
+  (let [logs (process [(request-sent "6.1" {:url "https://example.org/img.png" :type "Image"})
+                       (response-received "6.1" {:status 200})
+                       (loading-finished "6.1")
+                       (request-sent "6.2" {:url "https://example.org/api" :type "XHR"})
+                       (response-received "6.2" {:status 200 :type "XHR"})
+                       (loading-finished "6.2")])]
+    (is (= 2 (count (dev/logs->requests logs))))
+    (is (= ["6.2"] (mapv :id (dev/logs->ajax logs))))
+    (is (every? dev/ajax? (dev/logs->ajax logs)))))
+
+(deftest non-network-logs-are-ignored
+  (let [logs (process [(log-entry "Page.frameStartedLoading" {:frameId "F1"})
+                       (request-sent "7.1" {:url "https://example.org/"})
+                       (response-received "7.1" {:status 200})
+                       (loading-finished "7.1")])]
+    (is (= ["7.1"] (mapv :id (dev/logs->requests logs))))))


### PR DESCRIPTION
Fixes #98.

`etaoin.dev/log->request` destructures `status` out of the response **headers**:

```clojure
:network/responsereceived
(let [{:keys [response]}                         params
      {:keys [headers mimeType remoteIPAddress]} response
      {:keys [status]}                           headers]   ;; <- headers, not response
```

CDP puts `status` on the `Network.Response` object itself, not inside its `headers` map. Nothing ever writes a `status` key into `headers`, so `[:response :status]` has been `nil` for every request `get-requests` / `get-ajax` / `logs->requests` has ever returned. Introduced with the namespace in bf61874 ("Devtools", #210, 2019-07-02).

With the destructuring moved up to `response`, against Chrome 151:

```clojure
(def d (e/chrome {:dev {} :headless true}))
(e/go d "https://clojure.org")
(frequencies (map #(-> % :response :status) (dev/get-requests d)))
;; => {200 24, 204 1, nil 1}
```

(the remaining `nil` is a request that never received a response.)

### A note on the approach

The discussion on #98 concluded that this needed the experimental `Network.responseReceivedExtraInfo` event, and that a fix would wait until that event left experimental status. That turns out not to be necessary for the status code — plain `Network.responseReceived` has carried it all along. `responseReceivedExtraInfo` still offers things `responseReceived` does not (raw unfiltered headers, cookie details), so it may remain worth having, but that seems separable from this issue.

Flagging this because it means the PR takes a different direction from what was discussed in the thread — happy to adjust or drop it if you'd rather go another way.

### Also included

- **`try-parse-int` now short-circuits non-strings.** DevTools sends a number and `Integer/parseInt` has no such overload, so without this every response would throw and catch a `ClassCastException` to arrive back at the value it started with.
- **`test/etaoin/unit/dev_test.clj`** — the first tests for `etaoin.dev`. Hermetic: log entries are built in the shape Chrome emits, so no browser is required. All 5 tests fail against the unfixed parser; one asserts against a decoy header literally named `status` so the wrong-map read cannot regress silently.
- **Three user-guide samples corrected.** `doc/01-user-guide.adoc` lines 1943, 2007 and 2129 had `:status nil` baked into their captured output, which is likely why this never looked wrong. Values are derived from each sample's own evidence: a 660-byte cached image and Google's autocomplete XHR are `200`; the `POST` to `gen_204` with `content-length "0"` is `204`. These blocks are evaluated by test-doc-blocks but use bare `;;` comments rather than `;; =>` assertions, so nothing was asserting the incorrect values.
- **CHANGELOG entry** under Unreleased.

### Verification

`unit` suite green on both lanes locally (macOS, JDK 25): 22 tests / 79 assertions / 0 failures under `bb test:jvm` and `bb test:bb`. `bb lint-kondo` and `bb lint-eastwood` both clean.

---

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).
- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. — #98 is open and was reopened by @lread to keep it on the radar; note the caveat above that the approach differs from what was discussed there.
- [x] This PR contains test(s) to protect against future regressions
- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
