### PR TITLE
fix: keep credentials out of thrown ex-data

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,8 @@ A release with an intentional breaking changes is marked with:
 ** The exceptions thrown by `upload-file` (when the file does not exist) and `print-page` (when the driver does not support it) no longer carry credentials.
 Both attached the whole driver map to their ex-data, including `:capabilities` -- which the user guide tells you to put provider tokens and proxy credentials in -- and an unredacted `:webdriver-url`.
 They now attach a driver map with `:capabilities` and `:env` dropped and any credentials stripped from `:webdriver-url`; the driver remains identifiable by `:type`, `:host` and `:port`.
+** `upload-file` now includes the offending `:path` in the ex-data of the `:etaoin/file` exception it throws.
+Previously the path was only available as prose in `:message`.
 ** Migrate to org.clj-commons/slingshot
 ** Bumped deps
 ({lread})

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,9 @@ A release with an intentional breaking changes is marked with:
 == Unreleased
 
 * Changes
+** The exceptions thrown by `upload-file` (when the file does not exist) and `print-page` (when the driver does not support it) no longer carry credentials.
+Both attached the whole driver map to their ex-data, including `:capabilities` -- which the user guide tells you to put provider tokens and proxy credentials in -- and an unredacted `:webdriver-url`.
+They now attach a driver map with `:capabilities` and `:env` dropped and any credentials stripped from `:webdriver-url`; the driver remains identifiable by `:type`, `:host` and `:port`.
 ** Migrate to org.clj-commons/slingshot
 ** Bumped deps
 ({lread})

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2957,7 +2957,7 @@
       (fill driver q path)
       (throw+ {:type    :etaoin/file
                :message message
-               :driver  driver}))))
+               :driver  (util/driver-for-report driver)}))))
 
 ;;
 ;; submit
@@ -3156,7 +3156,7 @@
   [driver _file & [_opts]]
   (throw+ {:type :etaoin/unsupported
            :message "This driver doesn't support printing pages to PDF."
-           :driver driver}))
+           :driver (util/driver-for-report driver)}))
 
 (defmethods print-page
   [:chrome :edge :firefox]

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2957,6 +2957,7 @@
       (fill driver q path)
       (throw+ {:type    :etaoin/file
                :message message
+               :path    path
                :driver  (util/driver-for-report driver)}))))
 
 ;;

--- a/src/etaoin/impl/util.clj
+++ b/src/etaoin/impl/util.clj
@@ -77,6 +77,24 @@
       (dissoc :user :password)
       uri/uri-str))
 
+(def ^:private credential-bearing-driver-keys
+  "Driver map keys that can hold secrets.
+
+  `:capabilities` is where the user guide tells folks to put provider tokens and
+  proxy credentials, and `:env` is arbitrary user-supplied environment."
+  [:capabilities :env])
+
+(defn driver-for-report
+  "Return `driver` with anything that can hold credentials dropped or masked.
+
+  Use when attaching a driver map to an exception, since ex-data routinely ends up
+  in test runner and CI output. A `:webdriver-url` is kept, minus any credentials
+  embedded in it, because knowing which endpoint you were talking to is the whole
+  point of including the driver."
+  [driver]
+  (cond-> (apply dissoc driver credential-bearing-driver-keys)
+    (:webdriver-url driver) (update :webdriver-url strip-url-creds)))
+
 (defn assoc-some
   "Associates a key with a value in a map, if and only if the value is
   not nil. From medley."

--- a/test/etaoin/unit/error_data_test.clj
+++ b/test/etaoin/unit/error_data_test.clj
@@ -51,6 +51,8 @@
     (is (= :etaoin/file (:type exd)))
     (testing "the message still names the file"
       (is (str/includes? (:message exd) "file-xyz.txt")))
+    (testing "the path is available as data, not only prose in the message"
+      (is (str/ends-with? (:path exd) "file-xyz.txt")))
     (testing "the driver is still identifiable"
       (is (= :safari (-> exd :driver :type))))
     (testing "no secret survives anywhere in ex-data"

--- a/test/etaoin/unit/error_data_test.clj
+++ b/test/etaoin/unit/error_data_test.clj
@@ -1,0 +1,67 @@
+(ns etaoin.unit.error-data-test
+  "Tests that thrown ex-data does not carry credentials.
+
+  Hermetic: both code paths under test throw before any WebDriver call is made,
+  so no driver and no browser are required."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [etaoin.api :as e]
+   [etaoin.impl.util :as util]
+   [etaoin.test-report]))
+
+(def ^:private secret-laden-driver
+  "A driver map shaped the way the user guide tells people to build one, secrets
+  and all. See doc/01-user-guide.adoc for the `browserless:token` example."
+  {:type          :safari
+   :host          "127.0.0.1"
+   :port          4444
+   :webdriver-url "https://user:sekret@ondemand.example.com/wd/hub"
+   :capabilities  {"browserless:token" "TOKEN-abc123"
+                   :proxy              {:httpProxy "puser:ppass@corp.proxy:8080"}}
+   :env           {"SAUCE_ACCESS_KEY" "ACCESS-KEY-xyz"}})
+
+(def ^:private secrets
+  ["sekret" "TOKEN-abc123" "ppass" "ACCESS-KEY-xyz"])
+
+(defn- leaked [ex-data-map]
+  (let [dump (pr-str ex-data-map)]
+    (filterv #(str/includes? dump %) secrets)))
+
+;; ---------------------------------------------------------------------------
+
+(deftest driver-for-report-drops-and-masks-credentials
+  (let [out (util/driver-for-report secret-laden-driver)]
+    (testing "credential-bearing keys are gone"
+      (is (not (contains? out :capabilities)))
+      (is (not (contains? out :env))))
+    (testing "credentials embedded in the webdriver url are stripped"
+      (is (= "https://ondemand.example.com/wd/hub" (:webdriver-url out))))
+    (testing "everything else is left alone"
+      (is (= :safari (:type out)))
+      (is (= "127.0.0.1" (:host out)))
+      (is (= 4444 (:port out))))
+    (testing "no secret survives anywhere"
+      (is (= [] (leaked out))))))
+
+(deftest upload-file-of-a-missing-file-does-not-leak
+  (let [exd (try
+              (e/upload-file secret-laden-driver {:tag :input} "/no/such/file-xyz.txt")
+              (catch Throwable ex (ex-data ex)))]
+    (is (= :etaoin/file (:type exd)))
+    (testing "the message still names the file"
+      (is (str/includes? (:message exd) "file-xyz.txt")))
+    (testing "the driver is still identifiable"
+      (is (= :safari (-> exd :driver :type))))
+    (testing "no secret survives anywhere in ex-data"
+      (is (= [] (leaked exd))))))
+
+(deftest print-page-on-an-unsupporting-driver-does-not-leak
+  ;; :safari has no print-page support, so this hits the :default method
+  (let [exd (try
+              (e/print-page secret-laden-driver "out.pdf")
+              (catch Throwable ex (ex-data ex)))]
+    (is (= :etaoin/unsupported (:type exd)))
+    (is (= :safari (-> exd :driver :type)))
+    (testing "no secret survives anywhere in ex-data"
+      (is (= [] (leaked exd))))))


### PR DESCRIPTION
Related to #716, which covers the same class of leak in the WebDriver client layer. This PR is independent of that one — it touches different code and needs no decision from #716 to be reviewable.

### Credentials in thrown ex-data

Two `throw+` sites in `etaoin.api` attach the entire driver map to the map they throw:

- `upload-file` (`:etaoin/file`, when the file does not exist) — src/etaoin/api.clj#L2957-L2960
- `print-page` (`:etaoin/unsupported`, `:default` method) — src/etaoin/api.clj#L3156-L3159

The driver map holds `:capabilities`, which doc/01-user-guide.adoc#L2683 tells you to put provider tokens and proxy credentials in, an unredacted `:webdriver-url`, which can carry HTTP basic credentials, and `:env`, which is arbitrary user-supplied environment. ex-data routinely ends up in test runner and CI output, so those secrets travel further than the exception does.

These are the only two `throw+` sites in the namespace that embed the driver map — I checked all of them.

Adds `util/driver-for-report` next to the existing `strip-url-creds`, and uses it at both sites. It drops the credential-bearing keys and *strips* credentials from `:webdriver-url` rather than dropping the key, because knowing which endpoint you were talking to is most of the reason to include the driver at all. `:type`, `:host` and `:port` survive, so the driver stays identifiable.

`:env` is included in the dropped set on the same reasoning as `:capabilities`. There is precedent for treating these as the sensitive group: `stop-driver` already does `(dissoc driver :process :args :env :capabilities :pre-stop-fns)` at src/etaoin/api.clj#L3360.

Deliberately a flat `dissoc` plus one `update`, not a deep walk. A deep walk over a driver map is unsafe: `:process` is a `babashka.process.Process`, which is `record?` and therefore `map?`, but throws `UnsupportedOperationException` on `empty`.

### The offending path in `upload-file` ex-data

Second commit, and additive. `upload-file` names the missing file in `:message` but nowhere else, so a caller that wants to know which path failed has to parse prose. It is now also `:path`. The message is unchanged, so nothing that reads it breaks.

### Tests

Adds `etaoin.unit.error-data-test`. Both code paths throw before any WebDriver call is made — `upload-file` on `.exists`, `print-page` on multimethod dispatch — so the tests need no driver and no browser. Both leak tests fail against the unfixed namespace.

### Verification

`unit` suite green on both lanes locally (macOS, JDK 25): 20 tests / 75 assertions / 0 failures under `bb test:jvm` and `bb test:bb`. `bb lint-kondo` and `bb lint-eastwood` both clean.

### A note on process

CONTRIBUTING asks contributors to start from an issue, and there is no issue for these two sites specifically — #716 covers the client layer. I went ahead because the change is small, self-contained and testable, but I am very happy to have it sit behind an issue, be folded into whatever you decide for #716, or be closed if you would rather handle it yourself.

---

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).
- [ ] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. — see the note on process above.
- [x] This PR contains test(s) to protect against future regressions
- [x] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue.
