### PR TITLE
dev: fix --suites/--browsers on current babashka

### DIFF
--- a/script/test.clj
+++ b/script/test.clj
@@ -13,19 +13,31 @@
 (def valid-browsers ["chrome" "firefox" "edge" "safari"])
 (def valid-suites ["api" "ide" "unit"])
 
+(defn- one-of
+  "Return a `:validate` `:pred` accepting any of `valid`.
+
+  Takes a single value or a collection of them, because babashka.cli has handed
+  repeatable option values to a pred both ways."
+  [valid]
+  (let [valid? (set valid)]
+    (fn [v]
+      (if (coll? v)
+        (every? valid? v)
+        (boolean (valid? v))))))
+
 (def cli-spec {:help {:desc "This usage help" :alias :h}
                :browsers {:ref "<name>"
                           :desc (str "Browsers to test against: " (str-coll valid-browsers))
                           :coerce []
                           :alias :b
-                          :validate {:pred #(every? (set valid-browsers) %)
+                          :validate {:pred (one-of valid-browsers)
                                      :ex-msg (fn [_m]
                                                (str "--browsers must specify from: " valid-browsers))}}
                :suites {:ref "<id>"
                         :desc (str "Suites to run: " (str-coll valid-suites))
                         :coerce []
                         :alias :s
-                        :validate {:pred #(every? (set valid-suites) %)
+                        :validate {:pred (one-of valid-suites)
                                    :ex-msg (fn [_m]
                                              (str "--suites must specify from: " valid-suites))}}
                :launch-virtual-display {:desc "Launch virtual display support for browsers (linux)"


### PR DESCRIPTION
Fixes #718.

`bb test:jvm --suites unit` -- the command `script/test_matrix.clj` generates for every CI job -- is currently rejected as invalid:

```
$ bb test:jvm --suites unit
ERROR: --suites must specify from: ["api" "ide" "unit"]
```

babashka.cli 0.12.80 added "Validate repeatable option values individually", so a `:validate` `:pred` on an option with a collection `:coerce` is now called once per element rather than once with the whole vector. Both preds in `script/test.clj` were written for the vector form, so they receive the string `"unit"` and `every?` walks its characters.

### Why accept both shapes rather than just switching

Swapping `#(every? (set valid-suites) %)` for `(set valid-suites)` would fix current bb and break older bb, trading one wrong assumption for another. `bb.edn` does not pin `org.babashka/cli` -- bb supplies it -- and `.github/workflows/test.yml` installs `bb: 'latest'`, so the repo does not control which version anyone has. `one-of` handles a single value or a collection, so the tasks work either way.

### Verification

Against bb 1.13.219:

| invocation | result |
|---|---|
| `--suites unit` | `{:suites ["unit"]}` |
| `--suites api ide` | `{:suites ["api" "ide"]}` |
| `--browsers chrome` | `{:browsers ["chrome"]}` |
| `--browsers chrome firefox` | `{:browsers ["chrome" "firefox"]}` |
| `--suites unit --browsers chrome` | both |
| `--suites bogus` | rejected, same message as before |
| `--browsers netscape` | rejected, same message as before |
| `--suites unit bogus` | rejected |

End to end, both lanes: `bb test:jvm --suites unit` and `bb test:bb --suites unit` each run 17 tests / 60 assertions / 0 failures. `bb lint-kondo` and `bb lint-eastwood` clean.

### Notes

No CHANGELOG entry: this is dev tooling with no effect on released Etaoin, matching how `76bc538`, `11a8f72` and `9d02cc3` were handled.

No test: `script/` is not on the test classpath -- neither the `:test` alias nor the `-test:bb` task includes it -- so there is nowhere for a unit test of a build script to live today. Adding that seemed like a separate change from unbreaking the matrix, so the verification above is manual. Say the word if you would rather have the harness first.

Also worth considering, and deliberately not done here: pinning `org.babashka/cli` in `bb.edn` and pinning `bb:` in the workflow rather than tracking `latest`. That would make toolchain moves deliberate instead of surprising, but it is a policy call rather than a fix.

---

- [x] I have read [CONTRIBUTING](https://github.com/clj-commons/etaoin/blob/master/CONTRIBUTING.md) and the [Etaoin Developer Guide](https://github.com/clj-commons/etaoin/blob/master/doc/02-developer-guide.adoc).
- [x] This PR corresponds to an issue that the Etaoin maintainers have agreed to address. — #718, which I filed alongside this; not yet triaged by a maintainer.
- [ ] This PR contains test(s) to protect against future regressions — see the note above on `script/` not being on the test classpath.
- [ ] I have updated [CHANGELOG.adoc](https://github.com/clj-commons/etaoin/blob/master/CHANGELOG.adoc) with a description of the addressed issue. — dev tooling only, consistent with prior `dev:`/`ci:` commits.
