### PR TITLE
fix: measure wait timeouts against real elapsed time

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,17 @@ A release with an intentional breaking changes is marked with:
 == Unreleased
 
 * Changes
+** `wait-predicate`, and therefore every `wait-*` fn, now measures its `:timeout` against real elapsed time.
+It previously subtracted `:interval` once per attempt and never accounted for time spent inside the predicate, so the real limit was the requested one plus the total time spent in the predicate.
+How far over depends on how slow the predicate is relative to `:interval`. A `wait-visible` against a local driver at default settings overshot by about 8%; a predicate taking 200ms against `{:timeout 1 :interval 0.05}` ran 5136ms instead of 1000ms.
+It matters most where a round trip rivals the interval: remote drivers, and the `{:timeout 30 :interval 0.100}` readiness poll used while connecting to a driver.
++
+NOTE: waits that previously succeeded only because they were granted more time than requested will now time out. If you see new timeouts, your `:timeout` was always too low -- raise it.
++
+The thrown `:etaoin/timeout` map gains `:elapsed-ms`. `:times` is unchanged in meaning, but its value now depends on how long the predicate takes, so it is no longer a fixed function of `:timeout` and `:interval`.
++
+The predicate is now always called at least once, whatever the `:timeout`.
+The undocumented `:time-rest` and `:times` opts were internal recursion state and are now ignored as inputs.
 ** Migrate to org.clj-commons/slingshot
 ** Bumped deps
 ({lread})

--- a/src/etaoin/api.clj
+++ b/src/etaoin/api.clj
@@ -2450,6 +2450,14 @@
   ([seconds]
    (Thread/sleep (long (* seconds 1000)))))
 
+(defn- monotonic-ms
+  "Milliseconds from an arbitrary origin, for measuring elapsed time.
+
+  Monotonic, so unlike wall-clock time it cannot jump backwards when the system
+  clock is adjusted mid-wait."
+  []
+  (quot (System/nanoTime) 1000000))
+
 (defmacro with-wait
   "Execute `body` waiting `seconds` before each form.
 
@@ -2467,9 +2475,9 @@
      ~@(interleave (repeat `(wait ~seconds)) body)))
 
 (defn wait-predicate
-  "Wakes up every `:interval` seconds to call `pred`.
-  Keeps this up until either `pred` returns truthy or `:timeout` has elapsed.
-  When `:timeout` has elapsed a slingshot exception is throws with `:message`.
+  "Calls `pred` repeatedly until it returns truthy or `:timeout` elapses,
+  sleeping `:interval` seconds between calls.
+  When `:timeout` elapses a slingshot exception is thrown with `:message`.
 
   Arguments:
 
@@ -2477,32 +2485,42 @@
   - `opts`: a map of optional parameters:
     - `:timeout` wait limit in seconds, [[*wait-timeout*]] by default;
     - `:interval` how long to wait between calls, [[*wait-interval*]] by default;
-    - `:message` a message that becomes a part of exception when timeout is reached."
+    - `:message` a message that becomes a part of exception when timeout is reached.
+
+  `:timeout` is real elapsed time, so it includes time spent inside `pred`
+  itself. A `pred` that talks to the WebDriver spends at least a round trip per
+  call, which can dominate `:interval`. The timeout is only checked between
+  calls; it never interrupts a `pred` that is already running.
+
+  `pred` is always called at least once, whatever `:timeout` is.
+
+  The thrown exception carries `:elapsed-ms`, the time actually spent waiting,
+  and `:times`, the number of calls made to `pred`."
 
   ([pred]
    (wait-predicate pred {}))
   ([pred opts]
-   (let [timeout   (get opts :timeout *wait-timeout*) ;; refactor this (call for java millisec)
-         time-rest (get opts :time-rest timeout)
-         interval  (get opts :interval *wait-interval*)
-         times     (get opts :times 0)
-         message   (get opts :message)]
-     (when (< time-rest 0)
-       (throw+ {:type      :etaoin/timeout
-                :message   message
-                :timeout   timeout
-                :interval  interval
-                :times     times
-                :predicate pred}))
-     (let [res (with-http-error
-                 (pred))]
-       (or res
-           (do
-             (wait interval)
-             (recur pred (assoc
-                           opts
-                           :time-rest (- time-rest interval)
-                           :times (inc times)))))))))
+   (let [timeout  (get opts :timeout *wait-timeout*)
+         interval (get opts :interval *wait-interval*)
+         message  (get opts :message)
+         start    (monotonic-ms)
+         deadline (+ start (long (* 1000 timeout)))]
+     (loop [times 0]
+       (or (with-http-error
+             (pred))
+           (let [times (inc times)
+                 now   (monotonic-ms)]
+             (if (<= deadline now)
+               (throw+ {:type       :etaoin/timeout
+                        :message    message
+                        :timeout    timeout
+                        :interval   interval
+                        :times      times
+                        :elapsed-ms (- now start)
+                        :predicate  pred})
+               (do
+                 (wait interval)
+                 (recur times)))))))))
 
 (defn wait-exists
   "Waits until `driver` finds element [[exists?]] via `q`.

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -500,12 +500,14 @@
                        {:timeout 1})
       (is false "should not be executed")
       (catch [:type :etaoin/timeout] data
-        (is (= (-> data (dissoc :predicate :time-rest))
+        (is (= (-> data (dissoc :predicate :times :elapsed-ms))
                {:type     :etaoin/timeout
                 :message  "Wait until :wait-span element has text -secret-"
                 :timeout  1
-                :interval 0.33
-                :times    4})))))
+                :interval 0.33}))
+        ;; :times is bounded by real elapsed time now, so how many calls
+        ;; fit depends on how long each one takes
+        (is (pos-int? (:times data))))))
   (testing "wait for non-existing text"
     (doto *driver*
       (e/refresh)
@@ -517,12 +519,14 @@
                        {:timeout 2})
       (is false "should not be executed")
       (catch [:type :etaoin/timeout] data
-        (is (= (-> data (dissoc :predicate :time-rest))
+        (is (= (-> data (dissoc :predicate :times :elapsed-ms))
                {:type     :etaoin/timeout
                 :message  "Wait until :wait-span element has text -dunno-whatever-foo-bar-"
                 :timeout  2
-                :interval 0.33
-                :times    7}))))))
+                :interval 0.33}))
+        ;; :times is bounded by real elapsed time now, so how many calls
+        ;; fit depends on how long each one takes
+        (is (pos-int? (:times data)))))))
 
 (deftest test-wait-has-text-everywhere
   (testing "wait for text simple"
@@ -542,12 +546,14 @@
                                   {:timeout 1})
       (is false "should not be executed")
       (catch [:type :etaoin/timeout] data
-        (is (= (-> data (dissoc :predicate :time-rest))
+        (is (= (-> data (dissoc :predicate :times :elapsed-ms))
                {:type     :etaoin/timeout
                 :message  "Wait until {:xpath \"*\"} element has text -secret-"
                 :timeout  1
-                :interval 0.33
-                :times    4})))))
+                :interval 0.33}))
+        ;; :times is bounded by real elapsed time now, so how many calls
+        ;; fit depends on how long each one takes
+        (is (pos-int? (:times data))))))
   (testing "wait for non-existing text"
     (doto *driver*
       (e/refresh)
@@ -558,12 +564,14 @@
                                   {:timeout 2})
       (is false "should not be executed")
       (catch [:type :etaoin/timeout] data
-        (is (= (-> data (dissoc :predicate :time-rest))
+        (is (= (-> data (dissoc :predicate :times :elapsed-ms))
                {:type     :etaoin/timeout
                 :message  "Wait until {:xpath \"*\"} element has text -dunno-whatever-foo-bar-"
                 :timeout  2
-                :interval 0.33
-                :times    7}))))))
+                :interval 0.33}))
+        ;; :times is bounded by real elapsed time now, so how many calls
+        ;; fit depends on how long each one takes
+        (is (pos-int? (:times data)))))))
 
 (deftest test-wait-has-class
   (testing "wait for an element has class"

--- a/test/etaoin/unit/wait_test.clj
+++ b/test/etaoin/unit/wait_test.clj
@@ -1,0 +1,109 @@
+(ns etaoin.unit.wait-test
+  "Unit tests for `etaoin.api/wait-predicate` timing.
+
+  Hermetic: the predicates here are plain functions, so no driver and no browser
+  are required."
+  (:require
+   [clj-commons.slingshot :refer [throw+ try+]]
+   [clojure.test :refer [deftest is testing]]
+   [etaoin.api :as e]
+   [etaoin.test-report]))
+
+(defn- timed
+  "Run `f`, return `[result elapsed-ms]`.
+
+  Result is `{:ok <value>}` or, on timeout, `{:timeout <ex-data>}`. Anything else
+  `f` throws is left to escape."
+  [f]
+  (let [start (System/nanoTime)
+        res   (try+ {:ok (f)} (catch [:type :etaoin/timeout] data {:timeout data}))]
+    [res (quot (- (System/nanoTime) start) 1000000)]))
+
+(defn- slow-false
+  "A predicate that always fails and takes `ms` to do it, like a WebDriver round trip."
+  [ms]
+  (fn [] (Thread/sleep (long ms)) false))
+
+;; ---------------------------------------------------------------------------
+
+(deftest timeout-is-real-elapsed-time-not-a-count-of-intervals
+  (testing "a predicate slower than the interval does not extend the timeout"
+    ;; Before this was deadline-based, `:time-rest` only ever decreased by
+    ;; `:interval`, so time spent inside `pred` was free. With a 200ms predicate
+    ;; and a 50ms interval, a nominal 1s timeout ran for roughly 5s.
+    (let [[res ms] (timed #(e/wait-predicate (slow-false 200)
+                                             {:timeout 1 :interval 0.05}))]
+      (is (:timeout res) "should have timed out")
+      (is (< ms 1600)
+          (str "nominal timeout was 1000ms, actually waited " ms "ms"))))
+
+  (testing "a fast predicate still honours the timeout"
+    (let [[res ms] (timed #(e/wait-predicate (constantly false)
+                                             {:timeout 1 :interval 0.05}))]
+      (is (:timeout res))
+      (is (<= 900 ms 1600)
+          (str "expected roughly 1000ms, waited " ms "ms")))))
+
+(deftest timeout-data-reports-what-actually-happened
+  (let [pred    (slow-false 100)
+        [res _] (timed #(e/wait-predicate pred {:timeout  1
+                                                :interval 0.05
+                                                :message  "no luck"}))
+        data    (:timeout res)]
+    (is (= :etaoin/timeout (:type data)))
+    (is (= "no luck" (:message data)))
+    (is (= 1 (:timeout data)))
+    (is (= 0.05 (:interval data)))
+    (is (identical? pred (:predicate data))
+        "the failing predicate travels with the exception")
+    (testing "elapsed-ms reflects the real wait"
+      (is (<= 900 (:elapsed-ms data) 1600)))
+    (testing "times counts calls actually made to pred"
+      ;; ~1000ms budget over ~150ms per cycle, so several calls but nowhere near
+      ;; the 20 an interval-counting implementation would have allowed.
+      (is (pos? (:times data)))
+      (is (< (:times data) 20)))))
+
+(deftest a-succeeding-predicate-returns-immediately
+  (testing "success is not delayed by the timeout"
+    (let [[res ms] (timed #(e/wait-predicate (constantly :found) {:timeout 30}))]
+      (is (= {:ok :found} res))
+      (is (< ms 100) (str "returned in " ms "ms")))))
+
+(deftest a-predicate-that-succeeds-on-a-later-call-still-returns-its-value
+  (let [calls (atom 0)
+        pred  #(when (< 2 (swap! calls inc)) :eventually)
+        [res _] (timed #(e/wait-predicate pred {:timeout 5 :interval 0.01}))]
+    (is (= {:ok :eventually} res))
+    (is (= 3 @calls))))
+
+(deftest an-http-error-from-pred-counts-as-a-failed-attempt
+  (testing "pred throwing an http error is treated as falsey, not propagated"
+    (let [calls    (atom 0)
+          pred     (fn []
+                     (swap! calls inc)
+                     (throw+ {:type :etaoin/http-error}))
+          [res ms] (timed #(e/wait-predicate pred {:timeout 0.2 :interval 0.05}))]
+      (is (:timeout res) "should time out rather than let the http error escape")
+      (is (pos? @calls))
+      (is (= @calls (-> res :timeout :times)))
+      (is (< ms 1000) (str "waited " ms "ms")))))
+
+(deftest zero-timeout-calls-pred-once-and-does-not-sleep
+  (testing "a zero timeout still gives pred one chance"
+    ;; `:interval` is deliberately huge: an implementation that sleeps before
+    ;; noticing it is out of time would take 5s to get here.
+    (let [calls    (atom 0)
+          [res ms] (timed #(e/wait-predicate (fn [] (swap! calls inc) false)
+                                             {:timeout 0 :interval 5}))]
+      (is (:timeout res))
+      (is (= 1 @calls))
+      (is (= 1 (-> res :timeout :times)))
+      (is (< ms 1000) (str "returned in " ms "ms"))))
+
+  (testing "a negative timeout also gives pred one chance"
+    (let [calls (atom 0)]
+      (try+
+        (e/wait-predicate (fn [] (swap! calls inc) false) {:timeout -1 :interval 5})
+        (catch [:type :etaoin/timeout] _))
+      (is (= 1 @calls)))))


### PR DESCRIPTION
`wait-predicate` tracked its budget by subtracting `:interval` once per attempt, so time
spent inside the predicate was free. The real limit was `:timeout` plus total predicate
time.

Now deadline-based off `System/nanoTime`, checked after each attempt.

Measured against a local chromedriver, `wait-visible` at default settings, nominal 7s:

| case | before | after |
|---|---|---|
| missing element | 7556ms (+8%) | 7315ms (+4.5%) |
| hidden element | 7655ms (+9%) | 7222ms (+3.2%) |
| 200ms pred, `{:timeout 1 :interval 0.05}` | 5136ms | 1239ms |

The last row is the remote-driver profile, where a round trip rivals `:interval`. Worst
case in-tree is the `{:timeout 30 :interval 0.100}` readiness poll in `-connect-driver`.

Correctness first — the time saved is small locally, material against a remote driver. A
wait that succeeds is unaffected (it has always returned as soon as the predicate went
truthy), and a full api suite run takes the same time before and after.

Checking the deadline *after* the attempt rather than before guarantees `pred` runs at
least once for any `:timeout`, and drops the sleep the loop performed immediately before
giving up. `discover-safari-webdriver-log` depends on that guarantee: it polls
`{:timeout 0 :interval 0.2}` and its throw is uncaught, so a zero-attempt timeout fails
Safari driver creation outright. Measured pre-fix: 103 zero-attempt timeouts in 5,000,000
entries; post-fix 300,000/300,000 make exactly one call.

Monotonic, so adjusting the system clock mid-wait cannot move the deadline.

Also:

- thrown map gains `:elapsed-ms`
- undocumented `:time-rest` / `:times` opts were internal recursion state, now ignored as
  inputs
- docstring no longer claims a fixed wake-up period; the period is `pred` duration +
  `:interval`
- negative `:timeout` now makes one attempt instead of zero

Possibly `[minor breaking]`, your call: a wait that only passed because it was granted more
than its stated budget will now time out. The honest reading is that its `:timeout` was
always too low.

Verified: `bb lint` clean; unit suite on JVM and bb; api suite on chrome, firefox and
safari.
