### PR TITLE
test: assert Safari AutoFill behaviour instead of describing it

### DIFF
--- a/env/test/resources/static/autofill-detached-password.html
+++ b/env/test/resources/static/autofill-detached-password.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>AutoFill fixture - password detached from form</title>
+    </head>
+    <body>
+        <!-- autofill-off.html with the password outside the form, attached via form=.
+             Still submitted, so the query string is unchanged. -->
+        <form id="af-form" autocomplete="off" method="GET">
+            <input id="af-user" name="login" type="text"><br>
+            <textarea id="af-text" name="message"></textarea><br>
+            <input id="af-submit" type="submit" value="Send"><br>
+        </form>
+        <input id="af-pass" name="passphrase" type="password" form="af-form" autocomplete="off">
+        <h3 id="af-end">Document end</h3>
+    </body>
+</html>

--- a/env/test/resources/static/autofill-distant-password.html
+++ b/env/test/resources/static/autofill-distant-password.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>AutoFill fixture - password inside form, far from username</title>
+    </head>
+    <body>
+        <!-- autofill-off.html with the password last instead of next to the username,
+             still a form member. With the detached variant this separates proximity
+             from form membership. -->
+        <form id="af-form" autocomplete="off" method="GET">
+            <input id="af-user" name="login" type="text"><br>
+            <textarea id="af-text" name="message"></textarea><br>
+            <input id="af-submit" type="submit" value="Send"><br>
+            <input id="af-pass" name="passphrase" type="password" autocomplete="off">
+        </form>
+        <h3 id="af-end">Document end</h3>
+    </body>
+</html>

--- a/env/test/resources/static/autofill-new-password.html
+++ b/env/test/resources/static/autofill-new-password.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>AutoFill fixture - autocomplete=new-password</title>
+    </head>
+    <body>
+        <!-- autofill-off.html with autocomplete=new-password on the password field. -->
+        <form id="af-form" autocomplete="off" method="GET">
+            <input id="af-user" name="login" type="text"><br>
+            <input id="af-pass" name="passphrase" type="password" autocomplete="new-password"><br>
+            <textarea id="af-text" name="message"></textarea><br>
+            <input id="af-submit" type="submit" value="Send"><br>
+        </form>
+        <h3 id="af-end">Document end</h3>
+    </body>
+</html>

--- a/env/test/resources/static/autofill-off.html
+++ b/env/test/resources/static/autofill-off.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>AutoFill fixture - autocomplete=off</title>
+    </head>
+    <body>
+        <!-- Login-shaped form declaring autocomplete=off, which Safari ignores on
+             password forms: reproduces the AutoFill focus steal. -->
+        <form id="af-form" autocomplete="off" method="GET">
+            <input id="af-user" name="login" type="text"><br>
+            <input id="af-pass" name="passphrase" type="password" autocomplete="off"><br>
+            <textarea id="af-text" name="message"></textarea><br>
+            <input id="af-submit" type="submit" value="Send"><br>
+        </form>
+        <h3 id="af-end">Document end</h3>
+    </body>
+</html>

--- a/env/test/resources/static/test.html
+++ b/env/test/resources/static/test.html
@@ -35,8 +35,13 @@
                 <input id="simple-input" name="login" type="text"><br>
                 <label>Password</label>
                 <!-- name=password causes masking in github actions output, name=passphrase does not -->
+                <!-- autocomplete=new-password stops Safari treating this as a saved-credential
+                     login form. Safari ignores autocomplete=off on password forms, and its
+                     AutoFill then moves focus on its own a few hundred ms after page load,
+                     stealing keystrokes from whichever field a test is filling. -->
                 <input id="simple-password"
-                       name="passphrase" type="password"><br>
+                       name="passphrase" type="password"
+                       autocomplete="new-password"><br>
                 <label>Message</label>
                 <textarea id="simple-textarea"
                           name="message"></textarea><br>

--- a/env/test/resources/static/test.html
+++ b/env/test/resources/static/test.html
@@ -35,10 +35,10 @@
                 <input id="simple-input" name="login" type="text"><br>
                 <label>Password</label>
                 <!-- name=password causes masking in github actions output, name=passphrase does not -->
-                <!-- autocomplete=new-password stops Safari treating this as a saved-credential
-                     login form. Safari ignores autocomplete=off on password forms, and its
-                     AutoFill then moves focus on its own a few hundred ms after page load,
-                     stealing keystrokes from whichever field a test is filling. -->
+                <!-- Safari ignores autocomplete=off on password forms and steals focus
+                     ~260ms after load; new-password opts out. Asserted per browser in
+                     etaoin.api-autofill-test. Safari half of
+                     https://github.com/clj-commons/etaoin/issues/646 -->
                 <input id="simple-password"
                        name="passphrase" type="password"
                        autocomplete="new-password"><br>

--- a/test/etaoin/api_autofill_test.clj
+++ b/test/etaoin/api_autofill_test.clj
@@ -1,0 +1,121 @@
+(ns etaoin.api-autofill-test
+  "Browser AutoFill behaviour that etaoin's fill tests depend on.
+
+  A browser that moves focus on its own corrupts `fill-active`, surfacing much later
+  as a wrong field value. Asserted here per browser, so a uniform pass does not hide
+  which browser actually has the quirk.
+
+  No WebKit bug tracks it: ignoring `autocomplete=off` on password forms is intended
+  behaviour. Safari half of https://github.com/clj-commons/etaoin/issues/646"
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [etaoin.api :as e]
+   [etaoin.api-test :as api-test]
+   [etaoin.test-report]))
+
+(use-fixtures :once api-test/test-server)
+(use-fixtures :each api-test/fixture-browsers)
+
+;; Safari AutoFill fires ~260ms after load (Safari 26.5.2)
+(def ^:private autofill-window-ms 1000)
+(def ^:private suggestion-window-ms 2000)
+
+(def ^:private fixtures
+  "Pages differ only in where the password field sits. `:keeps-focus` is what each
+  browser does. Safari classifies a password next to a text input as a login form;
+  proximity is the trigger, not form membership."
+  [{:page        "autofill-off.html"
+    :markup      "in form, next to username, autocomplete=off"
+    :keeps-focus {:safari false, :chrome true, :firefox true, :edge true}}
+   {:page        "autofill-distant-password.html"
+    :markup      "in form, after submit button, autocomplete=off"
+    :keeps-focus {:safari true, :chrome true, :firefox true, :edge true}}
+   {:page        "autofill-detached-password.html"
+    :markup      "outside form, via form= attribute"
+    :keeps-focus {:safari true, :chrome true, :firefox true, :edge true}}
+   {:page        "autofill-new-password.html"
+    :markup      "next to username, autocomplete=new-password"
+    :keeps-focus {:safari true, :chrome true, :firefox true, :edge true}}])
+
+;; test.html uses new-password. Moving the field works too, but controls serialize in
+;; DOM order, so reordering changes the query string its submit assertions check.
+
+(defn- active-id [driver]
+  (e/js-execute driver "var a = document.activeElement;
+                        return a ? (a.id || a.tagName) : 'null'"))
+
+(defn- focus-then-wait
+  "Click the password field on `page`, wait out the AutoFill window, return what is
+  focused.
+
+  Safari drops clicks (https://github.com/clj-commons/etaoin/issues/683), leaving BODY
+  focused. Reload and retry rather than reporting a dropped click as an AutoFill result."
+  [driver page]
+  (loop [tries 3]
+    (e/go driver (api-test/test-server-url page))
+    (e/wait-visible driver {:id :af-end})
+    (e/click driver :af-pass)
+    (if (and (= "BODY" (active-id driver)) (pos? tries))
+      (recur (dec tries))
+      (do (Thread/sleep (long autofill-window-ms))
+          (active-id driver)))))
+
+(deftest autofill-moves-focus-only-on-safari-and-only-next-to-a-username
+  (doseq [{:keys [page markup keeps-focus]} fixtures]
+    (testing markup
+      (let [browser (e/driver-type api-test/*driver*)
+            keeps?  (get keeps-focus browser ::unknown)
+            landed  (focus-then-wait api-test/*driver* page)]
+        (cond
+          (= ::unknown keeps?)
+          (is false (format "%s: no recorded behaviour for %s, landed on %s"
+                            (name browser) page landed))
+
+          keeps?
+          (is (= "af-pass" landed)
+              (format "%s should keep focus with %s but moved it to %s; fill-active now types into the wrong element"
+                      (name browser) markup landed))
+
+          :else
+          (is (= "af-user" landed)
+              (format "%s should ignore autocomplete=off and pull focus to the username field, but focus stayed on %s; if fixed, test.html no longer needs new-password"
+                      (name browser) landed)))))))
+
+(deftest automation-clicks-count-as-genuine-user-activation
+  (testing "a WebDriver click is user-initiated as far as the browser is concerned"
+    ;; Gives the suggestion test its meaning: an absent suggestion could otherwise just
+    ;; mean the browser never believed a user touched the field.
+    (e/go api-test/*driver* (api-test/test-server-url "autofill-new-password.html"))
+    (e/wait-visible api-test/*driver* {:id :af-end})
+    (let [activation #(e/js-execute api-test/*driver*
+                                    "return navigator.userActivation
+                                              ? navigator.userActivation.hasBeenActive
+                                              : nil")]
+      (if (nil? (activation))
+        (is (not (e/driver? api-test/*driver* :safari))
+            "Safari should support navigator.userActivation")
+        (do
+          (is (false? (activation)) "no activation before any input")
+          (e/click api-test/*driver* :af-pass)
+          (is (true? (activation)) "a WebDriver click is a genuine user activation"))))))
+
+(deftest automation-sees-no-strong-password-suggestion
+  (testing "dwelling on a focused new-password field does not fill it"
+    ;; Hand-driven Safari offers a strong password here; automation does not, because an
+    ;; Automation window "cannot access Safari's normal browsing history, AutoFill data,
+    ;; or other sensitive information"
+    ;; -- https://webkit.org/blog/6900/webdriver-support-in-safari-10/
+    ;; The classification still runs though: the focus theft above happens in the same
+    ;; window. Only the data is withheld.
+    ;;
+    ;; The panel is native UI, invisible to the DOM and to screenshots, so this asserts
+    ;; only that no value appears and typing still lands.
+    (e/go api-test/*driver* (api-test/test-server-url "autofill-new-password.html"))
+    (e/wait-visible api-test/*driver* {:id :af-end})
+    (e/click api-test/*driver* :af-pass)
+    (Thread/sleep (long suggestion-window-ms))
+    (is (= "" (e/get-element-value api-test/*driver* :af-pass))
+        (format "%s filled the field under automation" (name (e/driver-type api-test/*driver*))))
+    (e/fill-active api-test/*driver* "Secret123")
+    (is (= "Secret123" (e/get-element-value api-test/*driver* :af-pass))
+        "typing after the dwell should still land in the password field")))

--- a/test/etaoin/api_test.clj
+++ b/test/etaoin/api_test.clj
@@ -147,6 +147,18 @@
   (e/go driver (test-server-url "test.html"))
   (e/wait-visible driver {:id :document-end}))
 
+(defn is-active
+  "Assert that `driver` has element `q` focused.
+
+  `fill-active` fills whatever element happens to be focused, so a test that
+  clicks a field and then fills it is relying on the browser to leave focus
+  where it was put. State that dependency here, so a browser that moves focus
+  on its own fails on this assertion instead of on a corrupted field value
+  several steps later."
+  [driver q]
+  (is (= (e/query driver q) (e/get-active-element driver))
+      (format "%s should be the active element" q)))
+
 (defmacro wait-url-change
   "Snapshots the URL in the browser that exists before the `trigger` is
   executed, then executes `trigger`, and then waits for the URL to
@@ -285,10 +297,13 @@
   (testing "fill active"
     (reload-test-page *driver*)
     (e/click *driver* :simple-input)
+    (is-active *driver* :simple-input)
     (e/fill-active *driver* "MyLogin")
     (e/click *driver* :simple-password)
+    (is-active *driver* :simple-password)
     (e/fill-active *driver* "MyPassword")
     (e/click *driver* :simple-textarea)
+    (is-active *driver* :simple-textarea)
     (e/fill-active *driver* "Some text")
     (wait-url-change *driver* #"login" (e/click *driver* :simple-submit))
     (is (str/ends-with? (e/get-url *driver*)
@@ -296,10 +311,13 @@
   (testing "fill active human"
     (reload-test-page *driver*)
     (e/click *driver* :simple-input)
+    (is-active *driver* :simple-input)
     (e/fill-human-active *driver* "MyLogin2")
     (e/click *driver* :simple-password)
+    (is-active *driver* :simple-password)
     (e/fill-human-active *driver* "MyPassword2")
     (e/click *driver* :simple-textarea)
+    (is-active *driver* :simple-textarea)
     (e/fill-human-active *driver* "Some text 2")
     (wait-url-change *driver* #"login" (e/click *driver* :simple-submit))
     (is (str/ends-with? (e/get-url *driver*)


### PR DESCRIPTION
Safari classifies a password input next to a text input as a login form and runs AutoFill
on it, moving focus ~260ms after load. `fill-active` then types into the username field and
the test fails several steps later with a corrupted value that names nothing.

`autocomplete=off` does not stop it — WebKit ignores that attribute on password forms by
design, so there is no WebKit bug to link. This is the unfixed Safari half of #646; the Edge
half was fixed with `autocomplete="off"`, the very attribute WebKit ignores.

`test.html` now uses `autocomplete="new-password"` on its password field.

## Assertions

New namespace `etaoin.api-autofill-test`, four fixtures differing only in password
placement:

| fixture | password field | safari | chrome | firefox |
|---|---|---|---|---|
| `autofill-off.html` | in form, next to username, `off` | **steals focus** | keeps | keeps |
| `autofill-distant-password.html` | in form, after submit, `off` | keeps | keeps | keeps |
| `autofill-detached-password.html` | outside form, via `form=` | keeps | keeps | keeps |
| `autofill-new-password.html` | next to username, `new-password` | keeps | keeps | keeps |

Expectations are per browser, not uniform: the safari/`off` row asserts focus **is** stolen,
so the test passes by reproducing the quirk and fails if WebKit fixes it — or if another
browser acquires it. `:edge` rows are inferred from #646, not measured.

`api_test.clj` gains an `is-active` assertion after each click in the two `fill active`
tests, so a browser moving focus fails there instead of on a corrupted value later.

## Findings (Safari 26.5.2, macOS 26.5.2)

- Proximity, not form membership, triggers the classification: `distant` keeps the field in
  the form, `detached` removes it, both suppress AutoFill.
- WebDriver clicks are genuine user activation — `navigator.userActivation` true for
  `click`/Actions/Tab, false for JS `.focus()`. Without this an absent strong-password
  suggestion could just mean the browser never saw a user. `:focus-visible` does not
  discriminate; Safari reports it true for programmatic focus.
- No strong-password suggestion under automation: no value, no `input` event, also confirmed
  on a live signup form using `new-password`. An Automation window "cannot access Safari's
  normal browsing history, AutoFill data, or other sensitive information"
  (https://webkit.org/blog/6900/webdriver-support-in-safari-10/). The classification still
  runs though — the focus theft happens in that same window. Only data is withheld.
  Hand-driven Safari does offer a strong password.

## Why not just move the field

Tried and reverted: controls serialize in DOM order, so reordering changes
`?login=1&passphrase=2&message=3` and breaks 11 assertions in `test-submit`, `test-input`,
`test-clear`, `test-combined-actions`. Detaching has the same effect. Both variants are kept
as fixtures.

## Limits

The suggestion panel is native UI, absent from the DOM and from WebDriver screenshots. The
test asserts only that no value appears and typing still lands, not that no panel is drawn.

`focus-then-wait` reloads and retries when the click is dropped (#683), so that defect is
not misreported as an AutoFill result.

## Verified

`bb lint` clean. `api-autofill-test` green on chrome, firefox, safari. Full api suite:
chrome 75 tests/280 assertions/0 failures, safari 75/292/0.
